### PR TITLE
Fix Q8.8 clamp bounds and neutralize market-facing wording

### DIFF
--- a/src/fpga_bridge.rs
+++ b/src/fpga_bridge.rs
@@ -38,7 +38,7 @@ impl FpgaBridge {
         Err("FPGA not found on any USB port".into())
     }
     
-    /// Send market stimuli to FPGA and read back spike states.
+    /// Send neural stimuli to FPGA and read back spike states.
     ///
     /// Protocol (16-neuron SiliconBridge v3.0):
     ///   TX: 0xAA + 32 bytes (16 × Q8.8 stimuli)
@@ -55,7 +55,7 @@ impl FpgaBridge {
         let mut tx_data = vec![0xAAu8]; // Sync byte
         for i in 0..16 {
             let s = stimuli.get(i).copied().unwrap_or(0.0);
-            let q8_8 = (s.clamp(-255.0, 255.0) * 256.0) as i16;
+            let q8_8 = (s.clamp(-127.99, 127.99) * 256.0) as i16;
             tx_data.extend_from_slice(&q8_8.to_be_bytes());
         }
 


### PR DESCRIPTION
## **User description**
## Summary
- Clamp neural stimuli to valid signed Q8.8 range before casting to i16: `[-127.99, 127.99]`.
- Update doc comment in `process_stimuli` from domain-specific "market stimuli" to neutral "neural stimuli`.

## Validation
- `cargo check --manifest-path /home/raulmc/silicon-bridge/Cargo.toml` passed in local environment.


___

## **CodeAnt-AI Description**
**Keep neural stimulus values within the valid range before sending them to the FPGA**

### What Changed
- Neural stimulus values are now clamped to the valid signed Q8.8 range before transmission, preventing oversized inputs from being sent to the FPGA.
- The bridge comment now uses neutral “neural stimuli” wording instead of “market stimuli.”

### Impact
`✅ Fewer invalid FPGA inputs`
`✅ More reliable stimulus delivery`
`✅ Clearer bridge documentation`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=aUwzMnuMjNjVuh3kqj1EQ0kUpk50g4bD0BjZ6gnwvu4&org=Limen-Neural)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
