### PR TITLE
chore(docs): add CLAUDE.md and expand gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,17 +5,19 @@ Cargo.lock
 
 # AI / agent tooling
 .kilo/
-.kilocode/
+.kilocode/state/
+.mimo/
 .mimocode/
-.opencode/
+.opencode/cache/
 .codex/
 .ai/
-.junie/
+.junie/state/
 .cursor/
 .cline/
 .swarm/
 .worktrees/
-.beads/
+.beads/*.db
+.beads/*.db-*
 
 # IDE
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,28 @@
-/target
+# Build / package
+/target/
 Cargo.lock
 *.crate
-.mimocode/
-.codex/
-.mimo/
-.cursor/
-.vscode/
+
+# AI / agent tooling
 .kilo/
+.kilocode/
+.mimocode/
+.opencode/
+.codex/
+.ai/
+.junie/
+.cursor/
+.cline/
+.swarm/
+.worktrees/
+.beads/
+
+# IDE
+.idea/
+.vscode/
+.zed/
+
+# OS / editor
+.DS_Store
+*.swp
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ Cargo.lock
 # AI / agent tooling
 .kilo/
 .kilocode/state/
-.mimo/
 .mimocode/
 .opencode/cache/
 .codex/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,4 @@
+<!-- Last updated: 2026-07-22 -->
 # CLAUDE.md
 
 @AGENTS.md
@@ -7,10 +8,21 @@ in [AGENTS.md](AGENTS.md); quality bar in [REVIEW.md](REVIEW.md).
 
 ## Identity
 
-Rust agent for **silicon-bridge**: Q8.8 fixed-point parameter export, optional UART
-spike bridge (`uart` feature / `serialport`), and Vivado timing-report parsing.
-Prefer a trait-stable public API, feature-gate hardware I/O, and keep Rust
-edition **2024**.
+Rust agent for **silicon-bridge**: Q8.8 fixed-point parameter export, optional
+UART (Universal Asynchronous Receiver-Transmitter) spike bridge (`uart` feature /
+`serialport`), and Vivado timing-report parsing. Prefer a trait-stable public
+API, feature-gate hardware I/O, and keep Rust edition **2024**.
+
+## Tools
+
+| Tool / command | Purpose |
+|---|---|
+| `cargo check` | Fast compile check |
+| `cargo test` | Unit tests and doctests |
+| `cargo fmt --check` | Formatting gate |
+| `cargo clippy --all-targets -- -D warnings` | Lint gate |
+| `cargo check --features uart` | UART feature compile (needs `serialport` / `libudev` on Linux) |
+| `cargo build --release` | Optimized library build |
 
 ## Do not
 
@@ -18,8 +30,9 @@ edition **2024**.
 - Commit secrets, API keys, DSNs, or credentials
 - Commit IDE project trees (for example `.idea/`, `.vscode/`)
 - Add `unsafe` without an explicit safety justification
-- Reimplement NIR HDF5 I/O in this crate (deferred; future work may depend on
-  `Limen-Neural/nir-rs` instead of a local parser)
+- Reimplement NIR (Neuromorphic Intermediate Representation) HDF5 I/O in this
+  crate (deferred; future work may depend on `Limen-Neural/nir-rs` instead of a
+  local parser)
 
 ## Local quality bar
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md
+
+@AGENTS.md
+
+Companion for Claude Code and similar agents. Constraints and conventions live
+in [AGENTS.md](AGENTS.md); quality bar in [REVIEW.md](REVIEW.md).
+
+## Identity
+
+Rust agent for **silicon-bridge**: Q8.8 fixed-point parameter export, optional UART
+spike bridge (`uart` feature / `serialport`), and Vivado timing-report parsing.
+Prefer a trait-stable public API, feature-gate hardware I/O, and keep Rust
+edition **2024**.
+
+## Do not
+
+- Downgrade the Rust edition from 2024 to 2021
+- Commit secrets, API keys, DSNs, or credentials
+- Commit IDE project trees (for example `.idea/`, `.vscode/`)
+- Add `unsafe` without an explicit safety justification
+- Reimplement NIR HDF5 I/O in this crate (deferred; future work may depend on
+  `Limen-Neural/nir-rs` instead of a local parser)
+
+## Local quality bar
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+cargo check --features uart   # needs serialport / libudev on Linux
+```
+
+UART is gated behind `#[cfg(feature = "uart")]`. Prefer `cargo test` without
+`--all-features` on runners that lack `libudev-dev` unless the workflow installs it.


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` companion that imports `AGENTS.md` and notes edition 2024 / UART feature / deferred NIR
- Expand `.gitignore` for AI agent dirs, IDE (`.idea/`, `.vscode/`, `.zed/`), and editor noise

## Test plan

- [x] `cargo test` (3 unit + 1 doctest)
- [x] `.idea/` is ignored and not committed