### PR TITLE
feat(fpga-export): define export traits and document silicon-hdl

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ let (_potentials, spikes) = bridge.process_stimuli(&stimuli)?;
 
 ```
 Q8.8:  value = raw_u16 / 256.0
-       raw   = round(value × 256)
+       raw   = clamp(value × 256, 0, 65535) truncated to u16
 Range: [0, 255.996]  (unsigned)
        [-128, 127.996]  (signed, two's complement)
 ```

--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ back spike states at runtime.
 
 ## Features
 
-- `FpgaParameterExporter` — serialize SNN weights/thresholds to Q8.8 `.mem` format
-- `to_q88(value)` — convert `f32` to Q8.8 fixed-point (`value × 256 → u16`)
-- `FpgaBridge` — async UART protocol for host-FPGA spike exchange
+- **Export traits** for hardware alignment with [silicon-hdl](https://github.com/Limen-Neural/silicon-hdl):
+  - `FixedPointEncode` — `f32` → Q8.8 (`u16`)
+  - `ParameterExport` — build the FPGA parameter bundle
+  - `MemFileWriter` — write `$readmemh` `.mem` files
+- `FpgaParameterExporter` — default implementation of those traits
+- `format_q88_hex` / `q88_to_f32` — Q8.8 helpers
+- `FpgaBridge` — UART protocol for host–FPGA spike exchange (`uart` feature)
 - `FpgaMetrics` — Vivado timing report parser (WNS, TNS, LUT utilization) for CI/CD gating
-- Generic `FixedPoint<INT_BITS, FRAC_BITS>` type (Q8.8, Q4.12, Q12.4, …)
-- Round-trip validation: export → program FPGA → read back → compare
 
 ## Installation
 
@@ -38,16 +40,16 @@ silicon-bridge = "0.1"
 ### Export Parameters
 
 ```rust
-use silicon_bridge::FpgaParameterExporter;
+use silicon_bridge::{FpgaParameterExporter, ParameterExport};
 
 let mut exporter = FpgaParameterExporter::new();
 exporter.set_thresholds(vec![0.6; 16]);
 exporter.set_weights(vec![vec![0.5; 16]; 16]);
 exporter.set_decay_rates(vec![0.9; 16]);
 
-let params = exporter.export();
+let params = ParameterExport::export(&exporter);
 // → params.thresholds, .weights, .decay_rates are Vec<u16> (Q8.8 format)
-// → ready for Vivado $readmemh
+// → ready for silicon-hdl WeightRam / NeuronParamRam via Vivado $readmemh
 ```
 
 ### UART Spike Readback
@@ -69,7 +71,8 @@ Range: [0, 255.996]  (unsigned)
        [-128, 127.996]  (signed, two's complement)
 ```
 
-Directly loadable by `WeightRam.sv` and `NeuronParamRam.sv`.
+Directly loadable by silicon-hdl `WeightRam.sv` and `NeuronParamRam.sv`
+([Limen-Neural/silicon-hdl](https://github.com/Limen-Neural/silicon-hdl)).
 
 ## Extracted from Production
 
@@ -81,8 +84,9 @@ training orchestrator so it works with any SNN framework.
 
 | Library | Purpose |
 |---------|---------|
-| [silicon-bridge-sv](https://github.com/Limen-Neural/silicon-bridge-sv) | FPGA bridge and protocol layer |
-| [silicon-distill-jl](https://github.com/Limen-Neural/silicon-distill-jl) | Julia training + distillation |
+| [silicon-hdl](https://github.com/Limen-Neural/silicon-hdl) | SystemVerilog core, bridge, and SoC for Basys3 / Artix-7 |
+| [SynapticDistill.jl](https://github.com/Limen-Neural/SynapticDistill.jl) | Julia training + distillation (Q8.8 export path) |
+| [neuromod](https://github.com/Limen-Neural/neuromod) | SNN dynamics / core runtime traits |
 
 ## License
 

--- a/src/fpga_export.rs
+++ b/src/fpga_export.rs
@@ -1,18 +1,62 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-//! FPGA Parameter Export - Spikenaut-v2 Deployment
+//! FPGA parameter export for [silicon-hdl](https://github.com/Limen-Neural/silicon-hdl).
 //!
-//! Q8.8 fixed-point parameter export for FPGA deployment.
-//! Converts learned parameters to hardware-compatible format.
+//! Converts trained SNN floats to unsigned **Q8.8** (`u16`) vectors and writes
+//! Vivado `$readmemh` `.mem` files consumable by `WeightRam` and `NeuronParamRam`
+//! in the silicon-hdl core library.
+//!
+//! ## Traits
+//!
+//! Hardware-facing crates should depend on the traits here rather than the
+//! concrete [`FpgaParameterExporter`] type when possible:
+//!
+//! - [`FixedPointEncode`] — `f32` → Q8.8 `u16`
+//! - [`ParameterExport`] — produce [`FpgaParameters`]
+//! - [`MemFileWriter`] — write `.mem` + metadata JSON
 
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::Write;
 use std::path::Path;
 
-/// FPGA parameter exporter for Spikenaut-v2
+/// Metadata / layout tag for the Q8.8 `.mem` bundle shared with silicon-hdl.
 ///
-/// Exports learned SNN parameters in Q8.8 fixed-point format
-/// for FPGA deployment with <35µs/tick target performance.
+/// Historical name from the Spikenaut deployment pipeline; kept for downstream
+/// tooling that keys on this string.
+pub const EXPORT_FORMAT_VERSION: &str = "Spikenaut-v2";
+
+/// Encode host floating-point values as unsigned Q8.8 (`u16`).
+///
+/// Q8.8 maps `value × 256` into a 16-bit word. Values outside the representable
+/// range are clamped.
+pub trait FixedPointEncode {
+    /// Convert one `f32` to Q8.8 fixed-point.
+    fn encode_q88(&self, value: f32) -> u16;
+}
+
+/// Export SNN parameters as an FPGA-facing Q8.8 parameter bundle.
+///
+/// The resulting [`FpgaParameters`] align with silicon-hdl RAM contents
+/// (`WeightRam`, `NeuronParamRam`).
+pub trait ParameterExport {
+    /// Build the full Q8.8 parameter set and metadata.
+    fn export(&self) -> FpgaParameters;
+}
+
+/// Write Q8.8 parameter vectors as Vivado `$readmemh` `.mem` files.
+pub trait MemFileWriter {
+    /// Error type for filesystem / I/O failures.
+    type Error;
+
+    /// Write `parameters.mem`, `parameters_weights.mem`, `parameters_decay.mem`,
+    /// and `parameters.json` under `output_dir`.
+    fn write_mem_files(&self, output_dir: impl AsRef<Path>) -> Result<(), Self::Error>;
+}
+
+/// Default FPGA parameter exporter for the silicon-hdl Q8.8 layout.
+///
+/// Exports learned SNN parameters in Q8.8 fixed-point format for FPGA
+/// deployment with a &lt;35µs/tick target latency budget.
 pub struct FpgaParameterExporter {
     thresholds: Vec<f32>,
     weights: Vec<Vec<f32>>,
@@ -67,49 +111,43 @@ impl FpgaParameterExporter {
         self.decay_rates = decay_rates;
     }
 
-    /// Convert f32 to Q8.8 fixed-point format
+    /// Convert `f32` to Q8.8 fixed-point format.
+    ///
+    /// Prefer [`FixedPointEncode::encode_q88`] when coding against the trait.
     pub fn to_q88(&self, value: f32) -> u16 {
-        // Q8.8: 8 integer bits, 8 fractional bits
-        // Range: 0.0 to 255.996
-        let scaled = value * 256.0;
-        scaled.clamp(0.0, 65535.0) as u16
+        self.encode_q88(value)
     }
 
-    /// Export parameters to FPGA-compatible format
+    /// Export parameters to FPGA-compatible format.
+    ///
+    /// Prefer [`ParameterExport::export`] when coding against the trait.
     pub fn export(&self) -> FpgaParameters {
-        let thresholds_q88: Vec<u16> = self.thresholds.iter().map(|&v| self.to_q88(v)).collect();
+        ParameterExport::export(self)
+    }
 
-        let weights_q88: Vec<u16> = self
-            .weights
-            .iter()
-            .flat_map(|row| row.iter())
-            .map(|&v| self.to_q88(v))
-            .collect();
+    /// Export parameters to `.mem` files for silicon-hdl / Vivado `$readmemh`.
+    ///
+    /// Prefer [`MemFileWriter::write_mem_files`] when coding against the trait.
+    pub fn export_to_mem_files<P: AsRef<Path>>(
+        &self,
+        output_dir: P,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.write_mem_files(output_dir)
+    }
 
-        let decay_rates_q88: Vec<u16> = self.decay_rates.iter().map(|&v| self.to_q88(v)).collect();
-
-        let metadata = FpgaMetadata {
-            version: "Spikenaut-v2".to_string(),
-            timestamp: chrono::Utc::now().to_rfc3339(),
-            num_neurons: self.thresholds.len(),
-            num_channels: if self.weights.is_empty() {
-                0
-            } else {
-                self.weights[0].len()
-            },
-            target_latency_us: 35.0,
-            memory_usage_kb: self.calculate_memory_usage(),
-        };
-
-        FpgaParameters {
-            thresholds: thresholds_q88,
-            weights: weights_q88,
-            decay_rates: decay_rates_q88,
-            metadata,
+    /// Create an exporter pre-populated with given parameters.
+    pub fn from_params(
+        thresholds: Vec<f32>,
+        weights: Vec<Vec<f32>>,
+        decay_rates: Vec<f32>,
+    ) -> Self {
+        Self {
+            thresholds,
+            weights,
+            decay_rates,
         }
     }
 
-    /// Calculate memory usage in KB
     fn calculate_memory_usage(&self) -> f32 {
         let total_params = self.thresholds.len()
             + self.weights.iter().map(|row| row.len()).sum::<usize>()
@@ -117,37 +155,6 @@ impl FpgaParameterExporter {
 
         // Each parameter is 2 bytes (u16) in Q8.8 format
         (total_params * 2) as f32 / 1024.0
-    }
-
-    /// Export parameters to .mem files for FPGA
-    pub fn export_to_mem_files<P: AsRef<Path>>(
-        &self,
-        output_dir: P,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        fs::create_dir_all(&output_dir)?;
-
-        let params = self.export();
-
-        Self::write_mem_file(
-            output_dir.as_ref().join("parameters.mem"),
-            &params.thresholds,
-        )?;
-        Self::write_mem_file(
-            output_dir.as_ref().join("parameters_weights.mem"),
-            &params.weights,
-        )?;
-        Self::write_mem_file(
-            output_dir.as_ref().join("parameters_decay.mem"),
-            &params.decay_rates,
-        )?;
-
-        let metadata_path = output_dir.as_ref().join("parameters.json");
-        let metadata_json = serde_json::to_string_pretty(&params)?;
-        fs::write(metadata_path, metadata_json)?;
-
-        self.print_export_summary(&params, output_dir);
-
-        Ok(())
     }
 
     fn write_mem_file(
@@ -161,7 +168,6 @@ impl FpgaParameterExporter {
         Ok(())
     }
 
-    /// Print export summary
     fn print_export_summary<P: AsRef<Path>>(&self, params: &FpgaParameters, output_dir: P) {
         println!("=== FPGA Parameter Export Summary ===");
         println!("Output Directory: {}", output_dir.as_ref().display());
@@ -187,20 +193,90 @@ impl FpgaParameterExporter {
         );
         println!("  parameters.json        - metadata and configuration");
         println!();
-        println!("SUCCESS: FPGA parameters ready for deployment");
+        println!("SUCCESS: FPGA parameters ready for silicon-hdl deployment");
     }
+}
 
-    /// Create an exporter pre-populated with given parameters.
-    pub fn from_params(
-        thresholds: Vec<f32>,
-        weights: Vec<Vec<f32>>,
-        decay_rates: Vec<f32>,
-    ) -> Self {
-        Self {
-            thresholds,
-            weights,
-            decay_rates,
+impl FixedPointEncode for FpgaParameterExporter {
+    fn encode_q88(&self, value: f32) -> u16 {
+        // Q8.8: 8 integer bits, 8 fractional bits
+        // Range: 0.0 to 255.996 (clamped into u16)
+        let scaled = value * 256.0;
+        scaled.clamp(0.0, 65535.0) as u16
+    }
+}
+
+impl ParameterExport for FpgaParameterExporter {
+    fn export(&self) -> FpgaParameters {
+        let thresholds_q88: Vec<u16> = self
+            .thresholds
+            .iter()
+            .map(|&v| self.encode_q88(v))
+            .collect();
+
+        let weights_q88: Vec<u16> = self
+            .weights
+            .iter()
+            .flat_map(|row| row.iter())
+            .map(|&v| self.encode_q88(v))
+            .collect();
+
+        let decay_rates_q88: Vec<u16> = self
+            .decay_rates
+            .iter()
+            .map(|&v| self.encode_q88(v))
+            .collect();
+
+        let metadata = FpgaMetadata {
+            version: EXPORT_FORMAT_VERSION.to_string(),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            num_neurons: self.thresholds.len(),
+            num_channels: if self.weights.is_empty() {
+                0
+            } else {
+                self.weights[0].len()
+            },
+            target_latency_us: 35.0,
+            memory_usage_kb: self.calculate_memory_usage(),
+        };
+
+        FpgaParameters {
+            thresholds: thresholds_q88,
+            weights: weights_q88,
+            decay_rates: decay_rates_q88,
+            metadata,
         }
+    }
+}
+
+impl MemFileWriter for FpgaParameterExporter {
+    type Error = Box<dyn std::error::Error>;
+
+    fn write_mem_files(&self, output_dir: impl AsRef<Path>) -> Result<(), Self::Error> {
+        fs::create_dir_all(&output_dir)?;
+
+        let params = ParameterExport::export(self);
+
+        Self::write_mem_file(
+            output_dir.as_ref().join("parameters.mem"),
+            &params.thresholds,
+        )?;
+        Self::write_mem_file(
+            output_dir.as_ref().join("parameters_weights.mem"),
+            &params.weights,
+        )?;
+        Self::write_mem_file(
+            output_dir.as_ref().join("parameters_decay.mem"),
+            &params.decay_rates,
+        )?;
+
+        let metadata_path = output_dir.as_ref().join("parameters.json");
+        let metadata_json = serde_json::to_string_pretty(&params)?;
+        fs::write(metadata_path, metadata_json)?;
+
+        self.print_export_summary(&params, output_dir);
+
+        Ok(())
     }
 }
 
@@ -213,7 +289,7 @@ impl Default for FpgaParameterExporter {
 /// Helper function to format Q8.8 value as hex string
 pub fn format_q88_hex(value: f32) -> String {
     let exporter = FpgaParameterExporter::new();
-    let q88_value = exporter.to_q88(value);
+    let q88_value = exporter.encode_q88(value);
     format!("{:04X}", q88_value)
 }
 
@@ -286,5 +362,18 @@ mod tests {
 
         // Expected memory: (16 + 256 + 16) * 2 bytes = 576 bytes = 0.5625 KB
         assert!((params.metadata.memory_usage_kb - 0.5625).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_trait_surface() {
+        let exporter = FpgaParameterExporter::from_params(vec![1.0], vec![vec![0.5]], vec![0.9]);
+
+        // Trait methods (not only inherent methods) are the stable hardware surface.
+        assert_eq!(FixedPointEncode::encode_q88(&exporter, 1.0), 256);
+        let params = ParameterExport::export(&exporter);
+        assert_eq!(params.metadata.version, EXPORT_FORMAT_VERSION);
+        assert_eq!(params.thresholds, vec![256]);
+        assert_eq!(params.weights, vec![128]);
+        assert_eq!(params.decay_rates, vec![230]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,9 @@
 //! SNN-to-FPGA deployment pipeline for FPGA-backed neuromorphic hardware.
 //!
 //! This crate provides:
-//! - **Q8.8 fixed-point parameter export** from trained SNN weights to `.mem` hex files
-//!   compatible with Vivado `$readmemh` synthesis
+//! - **Q8.8 fixed-point parameter export** (`FixedPointEncode`, `ParameterExport`,
+//!   `MemFileWriter`) for [silicon-hdl](https://github.com/Limen-Neural/silicon-hdl)
+//!   `WeightRam` / `NeuronParamRam` via Vivado `$readmemh`
 //! - **FPGA spike readback** over UART using the SiliconBridge v3.0 protocol
 //! - **Vivado timing report parsing** for WNS/LUT utilization CI/CD gating
 //!
@@ -46,7 +47,8 @@ mod fpga_bridge;
 
 // Re-export public API
 pub use fpga_export::{
-    FpgaMetadata, FpgaParameterExporter, FpgaParameters, format_q88_hex, q88_to_f32,
+    EXPORT_FORMAT_VERSION, FixedPointEncode, FpgaMetadata, FpgaParameterExporter, FpgaParameters,
+    MemFileWriter, ParameterExport, format_q88_hex, q88_to_f32,
 };
 
 pub use fpga_metrics::FpgaMetrics;


### PR DESCRIPTION
## Summary

- Add public traits `FixedPointEncode`, `ParameterExport`, and `MemFileWriter` (implemented by `FpgaParameterExporter`)
- Re-export traits + `EXPORT_FORMAT_VERSION` from the crate root
- Update README / rustdoc to reference [silicon-hdl](https://github.com/Limen-Neural/silicon-hdl) instead of obsolete repo names
- Keep inherent methods as thin wrappers for backward compatibility

Closes #7

## Test plan

- [x] `cargo test` (4 unit + 1 doctest)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Trait smoke test covers encode + export surface