### PR TITLE
docs: add silicon-bridge runtime/deployment boundary matrix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/lib.rs"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"
-rand = "0.8"
 serialport = { version = "4.3", optional = true }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ back spike states at runtime.
 - `FpgaParameterExporter` — default implementation of those traits
 - `format_q88_hex` / `q88_to_f32` — Q8.8 helpers
 - `FpgaBridge` — UART protocol for host–FPGA spike exchange (`uart` feature)
-- `FpgaMetrics` — Vivado timing report parser (WNS, TNS, LUT utilization) for CI/CD gating
+- `FpgaMetrics` — Vivado timing report parser (**WNS** for CI/CD gating; LUT field reserved / not parsed yet)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ Range: [0, 255.996]  (unsigned)
        [-128, 127.996]  (signed, two's complement)
 ```
 
-Directly loadable by `WeightRam.sv` and `NeuronParamRam.sv`.
+Directly loadable by silicon-hdl `WeightRam.sv` and `NeuronParamRam.sv`
+([Limen-Neural/silicon-hdl](https://github.com/Limen-Neural/silicon-hdl)).
+
+## Repo boundaries
+
+See [docs/boundary-matrix.md](docs/boundary-matrix.md) for what this crate owns
+versus `neuromod`, `brainstem-daemon`, `limbic-critic`, and `silicon-hdl`.
 
 ## Extracted from Production
 
@@ -81,8 +87,9 @@ training orchestrator so it works with any SNN framework.
 
 | Library | Purpose |
 |---------|---------|
-| [silicon-bridge-sv](https://github.com/Limen-Neural/silicon-bridge-sv) | FPGA bridge and protocol layer |
-| [silicon-distill-jl](https://github.com/Limen-Neural/silicon-distill-jl) | Julia training + distillation |
+| [silicon-hdl](https://github.com/Limen-Neural/silicon-hdl) | SystemVerilog core, bridge, and SoC |
+| [neuromod](https://github.com/Limen-Neural/neuromod) | SNN dynamics / core runtime |
+| [SynapticDistill.jl](https://github.com/Limen-Neural/SynapticDistill.jl) | Julia training + distillation |
 
 ## License
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -70,7 +70,7 @@ Lists in CHANGELOG.md need a blank line before them:
 
 ### Unused dependencies
 
-Check if new dependencies are actually imported. `rand` is currently listed but unused — avoid adding more dead dependencies.
+Check if new dependencies are actually imported. Do not reintroduce unused crates (e.g. the former unused `rand` dependency).
 
 ## AI reviewer notes
 

--- a/docs/boundary-matrix.md
+++ b/docs/boundary-matrix.md
@@ -15,7 +15,9 @@ parameters and FPGA hardware in the Limen-Neural stack. It:
    `$readmemh` `.mem` files
 2. Optionally exchanges stimuli / spikes with the FPGA over **UART**
    (`uart` feature)
-3. Parses **Vivado timing reports** (WNS, TNS, utilization) for CI gating
+3. Parses **Vivado timing reports for WNS** (worst negative slack) for CI gating.
+   `FpgaMetrics` also *exposes* a `lut_utilization` field, but loaders currently leave
+   it at `0.0` and **do not parse TNS** — do not treat TNS or LUT % as enforced gates yet
 
 It is **not** a spiking runtime, training loop, or HDL library.
 
@@ -46,7 +48,7 @@ training / runtime crates
 | `.mem` generation | Hex lines for `$readmemh` (thresholds, weights, decay) |
 | Export trait surface | Traits such as fixed-point encode / parameter export / mem write (for silicon-hdl alignment) |
 | UART host client | SiliconBridge-style host protocol when `uart` is enabled |
-| Timing metrics | Parse Vivado reports for CI gates |
+| Timing metrics | Parse WNS from Vivado timing summary reports for CI gates (TNS / LUT % not yet) |
 | Deployment metadata | Version/timestamp/size of exported parameter sets |
 
 ## Does not own
@@ -72,8 +74,10 @@ Current and intentional:
 |-------|-----|
 | `serde` / `serde_json` | Parameter metadata JSON |
 | `chrono` | Export timestamps |
-| `rand` | Existing support code paths |
 | `serialport` (optional) | UART feature only |
+
+Do **not** list unused crates as allowed. `rand` was previously in `Cargo.toml` with
+no `src/` imports; it is not an intentional dependency (see REVIEW.md).
 
 Future (allowed when explicitly landed):
 

--- a/docs/boundary-matrix.md
+++ b/docs/boundary-matrix.md
@@ -1,0 +1,139 @@
+# silicon-bridge runtime / deployment boundary matrix
+
+Planning document for GitHub [#3](https://github.com/Limen-Neural/silicon-bridge/issues/3)
+and Linear [LIM-306](https://linear.app/rpd-34/issue/LIM-306) /
+[LIM-589](https://linear.app/rpd-34/issue/LIM-589).
+
+This is **documentation only** — no runtime behavior changes.
+
+## Purpose
+
+`silicon-bridge` is the **host-side deployment bridge** between trained SNN
+parameters and FPGA hardware in the Limen-Neural stack. It:
+
+1. Converts float SNN parameters to **unsigned Q8.8** and writes Vivado
+   `$readmemh` `.mem` files
+2. Optionally exchanges stimuli / spikes with the FPGA over **UART**
+   (`uart` feature)
+3. Parses **Vivado timing reports** (WNS, TNS, utilization) for CI gating
+
+It is **not** a spiking runtime, training loop, or HDL library.
+
+## Layer placement
+
+| Layer | Role | Example repos |
+|-------|------|---------------|
+| Core SNN / traits | Neuron dynamics, shared trait contracts | `neuromod` |
+| Sensory / extract | Continuous→spike, MoE→SNN parameters | `axon-encoder`, `engram-parser` |
+| Topology / train | Connectivity, plasticity, offline training | `synaptic-mesh`, `plasticity-lab` |
+| Reward / critic | Neuromodulator-style signals | `limbic-critic` |
+| Runtime host | Headless inference orchestration | `brainstem-daemon` |
+| **Deployment (this crate)** | **Q8.8 export, UART host, metrics** | **`silicon-bridge`** |
+| Hardware RTL | SystemVerilog core / bridge / SoC | **`silicon-hdl`** |
+
+```text
+training / runtime crates
+        │  float thresholds, weights, decay
+        ▼
+  silicon-bridge   ──.mem / UART──►  silicon-hdl (FPGA)
+```
+
+## Owns
+
+| Area | Detail |
+|------|--------|
+| Fixed-point export | Q8.8 encode/decode helpers and parameter bundles |
+| `.mem` generation | Hex lines for `$readmemh` (thresholds, weights, decay) |
+| Export trait surface | Traits such as fixed-point encode / parameter export / mem write (for silicon-hdl alignment) |
+| UART host client | SiliconBridge-style host protocol when `uart` is enabled |
+| Timing metrics | Parse Vivado reports for CI gates |
+| Deployment metadata | Version/timestamp/size of exported parameter sets |
+
+## Does not own
+
+| Area | Owner |
+|------|--------|
+| LIF / HH / other neuron dynamics | `neuromod` |
+| Encoding continuous signals to spikes | `axon-encoder` |
+| MoE weight extraction | `engram-parser` |
+| Online / offline training | `plasticity-lab` |
+| Reward / risk modulators | `limbic-critic` |
+| Process orchestration / daemon lifecycle | `brainstem-daemon` |
+| SystemVerilog RTL, Vivado project trees | **`silicon-hdl`** (formerly informal “Spikenaut-Hardware”) |
+| Domain adapters (trading, mining telemetry) | Out of org core; must not leak into this crate |
+| Full SNN simulator | Out of scope |
+| NIR HDF5 graph I/O | Deferred; shared crate (`nir-rs`) if/when wired — not reimplemented here |
+
+## Allowed dependencies
+
+Current and intentional:
+
+| Crate | Why |
+|-------|-----|
+| `serde` / `serde_json` | Parameter metadata JSON |
+| `chrono` | Export timestamps |
+| `rand` | Existing support code paths |
+| `serialport` (optional) | UART feature only |
+
+Future (allowed when explicitly landed):
+
+| Crate | Why |
+|-------|-----|
+| `nir-rs` (Limen-Neural) | NIR → Q8.8 mapping without local HDF5 reimplementation |
+
+## Forbidden dependencies / content
+
+- Hard dependency on domain products (trading, mining, HFT adapters)
+- Embedding or vendoring silicon-hdl RTL
+- Pulling full `neuromod` simulation stacks solely to re-export dynamics
+- Secrets, DSNs, or machine-local paths in source
+- Treating this crate as the org-wide “core SNN library”
+
+## Boundaries vs sibling repos
+
+### vs `neuromod`
+
+- **neuromod**: core dynamics and shared trait *contracts* for neurons/networks.
+- **silicon-bridge**: takes *already trained* parameters (floats) and prepares them for FPGA.
+- Do not move LIF update loops into silicon-bridge.
+
+### vs `limbic-critic`
+
+- **limbic-critic**: modulator / reward vectors.
+- **silicon-bridge**: does not interpret reward; may only receive numeric params if a pipeline feeds them as weights/thresholds elsewhere.
+
+### vs `brainstem-daemon`
+
+- **brainstem-daemon**: long-running inference host / orchestration.
+- **silicon-bridge**: library used *by* hosts for FPGA export or UART; not a daemon.
+
+### vs `silicon-hdl`
+
+- **silicon-hdl**: single source of truth for RTL (`WeightRam`, `NeuronParamRam`, `SiliconBridge`, …).
+- **silicon-bridge**: host tools and parameter formats that must **align** with those modules.
+- Alignment issues (widths, file names, UART frames) are coordinated across both repos; RTL changes land in silicon-hdl.
+
+## Domain leaks, risks, sequencing
+
+| Risk | Mitigation |
+|------|------------|
+| Old “Spikenaut-Hardware” naming | Prefer **silicon-hdl** in all new docs |
+| Trait drift vs HDL RAM layout | Define export traits in silicon-bridge; HDL alignment issues track parity |
+| NIR reimplementation per crate | Defer NIR; use shared `nir-rs` later |
+| CI with `uart` / serialport | Feature-gate; avoid requiring `libudev` on all runners |
+| Cargo `docs/` exclude | Boundary doc lives in git under `docs/` for humans; crate package may exclude it |
+
+**Suggested sequence (planning):**
+
+1. Stable export traits + silicon-hdl docs (GitHub #7)
+2. HDL interface alignment issue on silicon-hdl
+3. Optional NIR consumer after shared IR crate exists
+
+## Validation checklist
+
+- [x] Purpose documented
+- [x] Owns / does-not-own explicit
+- [x] Allowed and forbidden dependencies listed
+- [x] Core vs runtime vs deployment/hardware layers explicit
+- [x] Risks and sequencing recorded
+- [x] Linkable from Linear (this file path: `docs/boundary-matrix.md`)

--- a/src/fpga_metrics.rs
+++ b/src/fpga_metrics.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! FPGA Synthesis Metrics — Vivado Report Parser
 //!
-//! Parses timing and resource utilization data from Vivado implementation reports.
+//! Parses **WNS** from Vivado timing summary reports for CI gating.
+//! LUT utilization is reserved on [`FpgaMetrics`] but not filled from reports yet.
 //! Extracted from Eagle-Lander's SpikingInferenceEngine (engine.rs).
 
 use serde::{Deserialize, Serialize};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!   `MemFileWriter`) for [silicon-hdl](https://github.com/Limen-Neural/silicon-hdl)
 //!   `WeightRam` / `NeuronParamRam` via Vivado `$readmemh`
 //! - **FPGA spike readback** over UART using the SiliconBridge v3.0 protocol
-//! - **Vivado timing report parsing** for WNS/LUT utilization CI/CD gating
+//! - **Vivado timing report parsing** for WNS-based CI/CD gating
 //!
 //! Licensed under either of MIT or Apache-2.0 at your option.
 //!


### PR DESCRIPTION
## Summary

- Add `docs/boundary-matrix.md` defining silicon-bridge purpose, ownership boundaries, deps, and sibling-repo placement
- Link the matrix from README and point ecosystem links at silicon-hdl / neuromod

Closes #3  
Linear: LIM-306 / LIM-589

## Test plan

- [x] Docs-only PR (no Rust changes)
- [x] Review matrix against current `Cargo.toml` features/deps