### PR TITLE
test(fpga-metrics): unit tests for WNS parser

### DIFF
--- a/src/fpga_metrics.rs
+++ b/src/fpga_metrics.rs
@@ -25,11 +25,12 @@ impl FpgaMetrics {
     /// Parse the WNS from a Vivado timing summary report text.
     ///
     /// Looks for the `WNS(ns)` column header row and extracts the first value.
+    /// Blank lines and dashed column-rule rows after the header are skipped.
     /// Returns `None` if the file format is not recognized.
     pub fn parse_from_report(report_text: &str) -> Option<f32> {
         // The Vivado timing summary has a line like:
         // "  WNS(ns)      TNS(ns)  ..."
-        // followed by a data row with the actual values.
+        // followed by a dashed rule, then a data row with the actual values.
         let mut found_header = false;
         for line in report_text.lines() {
             let trimmed = line.trim();
@@ -38,8 +39,12 @@ impl FpgaMetrics {
                 continue;
             }
             if found_header && !trimmed.is_empty() {
-                // First token of the data row is WNS
+                // First token of the data row is WNS. Skip dashed separator rows
+                // (e.g. "-------      -------") that Vivado prints under headers.
                 if let Some(wns_str) = trimmed.split_whitespace().next() {
+                    if !wns_str.is_empty() && wns_str.bytes().all(|b| b == b'-') {
+                        continue;
+                    }
                     return wns_str.parse::<f32>().ok();
                 }
                 break;
@@ -78,8 +83,8 @@ mod tests {
     use super::*;
     use std::io::Write;
 
-    /// Timing-summary excerpt in the shape Vivado emits, minus the column-rule
-    /// row (see `separator_row_is_not_skipped`).
+    /// Timing-summary excerpt in the shape Vivado emits (header plus data row).
+    /// The dashed column-rule case is covered by `skips_dashed_separator_row`.
     const TIMING_SUMMARY: &str = "\
 ------------------------------------------------------------------
 | Tool Version : Vivado v2022.2 (64-bit)
@@ -157,15 +162,14 @@ Design Timing Summary
         assert!(FpgaMetrics::parse_from_report(report).is_none());
     }
 
-    /// Vivado prints a rule of dashes under the column headers. The parser
-    /// treats it as the data row, so a verbatim report currently yields `None`.
-    /// This pins today's behavior; loosen it when the parser learns to skip
-    /// separator rows.
+    /// Vivado prints a dashed rule under the column headers. That row must be
+    /// skipped so the following numeric data row supplies WNS.
     #[test]
-    fn separator_row_is_not_skipped() {
+    fn skips_dashed_separator_row() {
         let report =
             "    WNS(ns)      TNS(ns)\n    -------      -------\n      2.345        0.000\n";
-        assert!(FpgaMetrics::parse_from_report(report).is_none());
+        let wns = FpgaMetrics::parse_from_report(report).expect("separator row blocked WNS parse");
+        assert_close(wns, 2.345);
     }
 
     #[test]

--- a/src/fpga_metrics.rs
+++ b/src/fpga_metrics.rs
@@ -42,7 +42,7 @@ impl FpgaMetrics {
                 // First token of the data row is WNS. Skip dashed separator rows
                 // (e.g. "-------      -------") that Vivado prints under headers.
                 if let Some(wns_str) = trimmed.split_whitespace().next() {
-                    if !wns_str.is_empty() && wns_str.bytes().all(|b| b == b'-') {
+                    if wns_str.bytes().all(|b| b == b'-') {
                         continue;
                     }
                     return wns_str.parse::<f32>().ok();
@@ -83,8 +83,8 @@ mod tests {
     use super::*;
     use std::io::Write;
 
-    /// Timing-summary excerpt in the shape Vivado emits (header plus data row).
-    /// The dashed column-rule case is covered by `skips_dashed_separator_row`.
+    /// Full Vivado timing-summary shape: header, dashed column-rule, then data.
+    /// `skips_dashed_separator_row` remains the focused unit case for the skip.
     const TIMING_SUMMARY: &str = "\
 ------------------------------------------------------------------
 | Tool Version : Vivado v2022.2 (64-bit)
@@ -95,6 +95,7 @@ Design Timing Summary
 ---------------------
 
     WNS(ns)      TNS(ns)  TNS Failing Endpoints  TNS Total Endpoints
+    -------      -------  ---------------------  -------------------
       2.345        0.000                      0                 1234
 ";
 
@@ -170,6 +171,12 @@ Design Timing Summary
             "    WNS(ns)      TNS(ns)\n    -------      -------\n      2.345        0.000\n";
         let wns = FpgaMetrics::parse_from_report(report).expect("separator row blocked WNS parse");
         assert_close(wns, 2.345);
+    }
+
+    #[test]
+    fn separator_row_then_eof_returns_none() {
+        let report = "    WNS(ns)      TNS(ns)\n    -------      -------\n";
+        assert!(FpgaMetrics::parse_from_report(report).is_none());
     }
 
     #[test]

--- a/src/fpga_metrics.rs
+++ b/src/fpga_metrics.rs
@@ -72,3 +72,127 @@ impl FpgaMetrics {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Timing-summary excerpt in the shape Vivado emits, minus the column-rule
+    /// row (see `separator_row_is_not_skipped`).
+    const TIMING_SUMMARY: &str = "\
+------------------------------------------------------------------
+| Tool Version : Vivado v2022.2 (64-bit)
+| Design       : Basys3_Top
+------------------------------------------------------------------
+
+Design Timing Summary
+---------------------
+
+    WNS(ns)      TNS(ns)  TNS Failing Endpoints  TNS Total Endpoints
+      2.345        0.000                      0                 1234
+";
+
+    /// Assert two `f32` values agree to within float round-trip noise.
+    fn assert_close(actual: f32, expected: f32) {
+        assert!(
+            (actual - expected).abs() < 1e-6,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn parses_wns_from_timing_summary() {
+        let wns = FpgaMetrics::parse_from_report(TIMING_SUMMARY).expect("WNS row not parsed");
+        assert_close(wns, 2.345);
+    }
+
+    #[test]
+    fn parses_negative_wns() {
+        let report = "WNS(ns)      TNS(ns)\n  -0.427        -1.882\n";
+        let wns = FpgaMetrics::parse_from_report(report).expect("negative WNS not parsed");
+        assert_close(wns, -0.427);
+    }
+
+    #[test]
+    fn skips_blank_lines_between_header_and_data() {
+        let report = "    WNS(ns)      TNS(ns)\n\n   \n\n      1.500        0.000\n";
+        let wns = FpgaMetrics::parse_from_report(report).expect("data row after blanks not parsed");
+        assert_close(wns, 1.5);
+    }
+
+    #[test]
+    fn tolerates_tabs_and_trailing_whitespace() {
+        let report = "\t WNS(ns) \t TNS(ns)  \n\t   0.875 \t 0.000  \n";
+        let wns = FpgaMetrics::parse_from_report(report).expect("tab-separated row not parsed");
+        assert_close(wns, 0.875);
+    }
+
+    #[test]
+    fn header_without_data_row_returns_none() {
+        let report = "    WNS(ns)      TNS(ns)\n";
+        assert!(FpgaMetrics::parse_from_report(report).is_none());
+    }
+
+    #[test]
+    fn missing_header_returns_none() {
+        let report = "Design Timing Summary\n      2.345        0.000\n";
+        assert!(FpgaMetrics::parse_from_report(report).is_none());
+    }
+
+    #[test]
+    fn empty_input_returns_none() {
+        assert!(FpgaMetrics::parse_from_report("").is_none());
+        assert!(FpgaMetrics::parse_from_report("   \n\n\t\n").is_none());
+    }
+
+    #[test]
+    fn garbage_input_returns_none() {
+        assert!(FpgaMetrics::parse_from_report("not a vivado report at all").is_none());
+    }
+
+    #[test]
+    fn non_numeric_first_token_returns_none() {
+        let report = "    WNS(ns)      TNS(ns)\n        N/A          N/A\n";
+        assert!(FpgaMetrics::parse_from_report(report).is_none());
+    }
+
+    /// Vivado prints a rule of dashes under the column headers. The parser
+    /// treats it as the data row, so a verbatim report currently yields `None`.
+    /// This pins today's behavior; loosen it when the parser learns to skip
+    /// separator rows.
+    #[test]
+    fn separator_row_is_not_skipped() {
+        let report =
+            "    WNS(ns)      TNS(ns)\n    -------      -------\n      2.345        0.000\n";
+        assert!(FpgaMetrics::parse_from_report(report).is_none());
+    }
+
+    #[test]
+    fn load_from_path_reads_report_file() {
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        file.write_all(TIMING_SUMMARY.as_bytes()).expect("write");
+        file.flush().expect("flush");
+        let path = file.path().to_str().expect("utf-8 path");
+
+        let metrics = FpgaMetrics::load_from_path(path).expect("metrics not loaded");
+        assert_close(metrics.wns_ns, 2.345);
+        assert_close(metrics.lut_utilization, 0.0);
+        assert!(metrics.synthesis_ok);
+    }
+
+    #[test]
+    fn load_from_path_returns_none_for_missing_file() {
+        assert!(FpgaMetrics::load_from_path("does/not/exist.rpt").is_none());
+    }
+
+    #[test]
+    fn load_from_path_returns_none_for_unparsable_report() {
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        file.write_all(b"no timing summary here\n").expect("write");
+        file.flush().expect("flush");
+        let path = file.path().to_str().expect("utf-8 path");
+
+        assert!(FpgaMetrics::load_from_path(path).is_none());
+    }
+}


### PR DESCRIPTION
## **User description**
Closes #20

## What

Adds 13 fixture-based unit tests for `FpgaMetrics::parse_from_report`, which had zero coverage. No production code changed — tests only.

| Test | Case |
|---|---|
| `parses_wns_from_timing_summary` | `WNS(ns)` header + data row → `2.345` |
| `parses_negative_wns` | negative slack (timing violation) |
| `skips_blank_lines_between_header_and_data` | blank / whitespace-only lines between header and data |
| `tolerates_tabs_and_trailing_whitespace` | tab and trailing-space variants |
| `header_without_data_row_returns_none` | header, then EOF → `None` |
| `missing_header_returns_none` | data row without header → `None` |
| `empty_input_returns_none` | `""` and whitespace-only → `None` |
| `garbage_input_returns_none` | non-report text → `None` |
| `non_numeric_first_token_returns_none` | `N/A` data row → `None` |
| `separator_row_is_not_skipped` | see note below |
| `load_from_path_reads_report_file` | valid report file → populated `FpgaMetrics` |
| `load_from_path_returns_none_for_missing_file` | missing path → `None` |
| `load_from_path_returns_none_for_unparsable_report` | readable but unparsable file → `None` |

## Note for reviewers: a real parser gap, pinned not fixed

Vivado prints a rule of dashes between the column headers and the numbers:

```
    WNS(ns)      TNS(ns)  ...
    -------      -------  ...
      2.345        0.000  ...
```

`parse_from_report` takes the first non-empty line after the header as the data row (`src/fpga_metrics.rs:40-46`), so it reads `-------`, fails to parse it as `f32`, and returns `None`. `load_from_project` would therefore return `None` on a genuine `Basys3_Top_timing_summary_routed.rpt`.

Fixing that is a behavior change and out of scope for #20 (one issue per PR), so `separator_row_is_not_skipped` pins today's behavior with a comment saying to loosen it once the parser learns to skip separator rows. A follow-up `fix(fpga-metrics)` issue should handle the parser itself.

## Validation

```
cargo fmt --check                          # clean
cargo clippy --all-targets -- -D warnings  # clean
cargo test                                 # 17 passed + 1 doctest
cargo check --features uart                # clean
```

No hardware required — the WNS path is pure text parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tTxpWTgqUD1rEgq6m23TH

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the WNS parser so Vivado's dashed column-rule row no longer blocks parsing — a genuine timing report now returns the WNS value instead of `None`. Adds 14 unit tests for `parse_from_report` and `load_from_path`. Closes #20.

- Blank lines and rows whose first token is all dashes are skipped before reading the data row.
- Tests cover happy path, negative slack, whitespace and tab tolerance, missing header/data, empty and garbage input, non-numeric tokens, and valid/missing/unparsable files.

<sup>Written for commit b55733cbb839341f768f00a28c68614c91e12df6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/silicon-bridge/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Parse WNS values from standard Vivado timing reports

### What Changed
- WNS extraction now skips Vivado’s dashed separator row and reads the numeric timing result that follows it
- Added coverage for standard Vivado reports, negative values, spacing variations, missing or invalid data, and loading reports from files

### Impact
`✅ Vivado timing reports now return WNS values`
`✅ Fewer missing FPGA metrics`
`✅ Reliable handling of invalid or incomplete reports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
