### PR TITLE
test(fpga-export): MemFileWriter .mem + metadata JSON round-trip tests

### DIFF
--- a/src/fpga_export.rs
+++ b/src/fpga_export.rs
@@ -376,4 +376,180 @@ mod tests {
         assert_eq!(params.weights, vec![128]);
         assert_eq!(params.decay_rates, vec![230]);
     }
+
+    /// Small, exactly-representable Q8.8 fixture used by the `.mem` writer tests.
+    ///
+    /// Every value is a multiple of 1/256, so Q8.8 encode/decode is lossless and
+    /// the expected hex words below can be asserted exactly.
+    fn mem_fixture() -> FpgaParameterExporter {
+        FpgaParameterExporter::from_params(
+            vec![1.0, 0.75],
+            vec![vec![0.5, 2.0], vec![0.25, 1.5]],
+            vec![0.5, 0.75],
+        )
+    }
+
+    /// Read a `.mem` file into its `$readmemh` lines.
+    fn read_hex_lines(path: impl AsRef<Path>) -> Vec<String> {
+        fs::read_to_string(path)
+            .expect("mem file should be readable")
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// Every `.mem` line must be an uppercase 4-digit hex word (`XXXX`).
+    fn assert_hex_line_format(lines: &[String]) {
+        for line in lines {
+            assert_eq!(line.len(), 4, "expected a 4-digit hex word, got {line:?}");
+            assert!(
+                line.chars()
+                    .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_lowercase()),
+                "expected an uppercase 4-digit hex word, got {line:?}"
+            );
+        }
+    }
+
+    /// Re-parse `$readmemh` lines back into Q8.8 words.
+    fn parse_hex_lines(lines: &[String]) -> Vec<u16> {
+        lines
+            .iter()
+            .map(|line| u16::from_str_radix(line, 16).expect("mem line should be valid hex"))
+            .collect()
+    }
+
+    #[test]
+    fn test_write_mem_files_via_trait_emits_expected_files() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let exporter = mem_fixture();
+
+        // Trait method (not only the inherent one) is the stable hardware surface.
+        MemFileWriter::write_mem_files(&exporter, dir.path())
+            .expect("write_mem_files should succeed");
+
+        let mut names: Vec<String> = fs::read_dir(dir.path())
+            .expect("output dir should be readable")
+            .map(|entry| {
+                entry
+                    .expect("dir entry should be readable")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            [
+                "parameters.json",
+                "parameters.mem",
+                "parameters_decay.mem",
+                "parameters_weights.mem",
+            ]
+        );
+
+        let thresholds = read_hex_lines(dir.path().join("parameters.mem"));
+        let weights = read_hex_lines(dir.path().join("parameters_weights.mem"));
+        let decay_rates = read_hex_lines(dir.path().join("parameters_decay.mem"));
+
+        assert_hex_line_format(&thresholds);
+        assert_hex_line_format(&weights);
+        assert_hex_line_format(&decay_rates);
+
+        // 1.0 -> 0x0100, 0.75 -> 0x00C0
+        assert_eq!(thresholds, ["0100", "00C0"]);
+        // Weights are flattened row-major: 0.5, 2.0, 0.25, 1.5
+        assert_eq!(weights, ["0080", "0200", "0040", "0180"]);
+        // 0.5 -> 0x0080, 0.75 -> 0x00C0
+        assert_eq!(decay_rates, ["0080", "00C0"]);
+    }
+
+    #[test]
+    fn test_mem_files_round_trip_to_parameter_export() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let exporter = mem_fixture();
+
+        MemFileWriter::write_mem_files(&exporter, dir.path())
+            .expect("write_mem_files should succeed");
+
+        let expected = ParameterExport::export(&exporter);
+
+        let thresholds = parse_hex_lines(&read_hex_lines(dir.path().join("parameters.mem")));
+        let weights = parse_hex_lines(&read_hex_lines(dir.path().join("parameters_weights.mem")));
+        let decay_rates = parse_hex_lines(&read_hex_lines(dir.path().join("parameters_decay.mem")));
+
+        assert_eq!(thresholds, expected.thresholds);
+        assert_eq!(weights, expected.weights);
+        assert_eq!(decay_rates, expected.decay_rates);
+
+        // The fixture is exactly representable, so Q8.8 decode returns the host floats.
+        let decoded: Vec<f32> = thresholds.iter().copied().map(q88_to_f32).collect();
+        for (got, want) in decoded.iter().zip([1.0_f32, 0.75]) {
+            assert!(
+                (got - want).abs() < 1e-6,
+                "Q8.8 round-trip drifted: got {got}, want {want}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_metadata_json_round_trips_to_fpga_parameters() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let exporter = mem_fixture();
+
+        MemFileWriter::write_mem_files(&exporter, dir.path())
+            .expect("write_mem_files should succeed");
+
+        let json = fs::read_to_string(dir.path().join("parameters.json"))
+            .expect("parameters.json should be readable");
+        let round_tripped: FpgaParameters =
+            serde_json::from_str(&json).expect("parameters.json should deserialize");
+
+        let expected = ParameterExport::export(&exporter);
+        assert_eq!(round_tripped.thresholds, expected.thresholds);
+        assert_eq!(round_tripped.weights, expected.weights);
+        assert_eq!(round_tripped.decay_rates, expected.decay_rates);
+
+        assert_eq!(round_tripped.metadata.version, EXPORT_FORMAT_VERSION);
+        assert_eq!(round_tripped.metadata.num_neurons, 2);
+        assert_eq!(round_tripped.metadata.num_channels, 2);
+        assert!(!round_tripped.metadata.timestamp.is_empty());
+        assert!((round_tripped.metadata.target_latency_us - 35.0).abs() < 1e-6);
+        // (2 thresholds + 4 weights + 2 decay rates) * 2 bytes = 16 bytes
+        assert!((round_tripped.metadata.memory_usage_kb - 16.0 / 1024.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_write_mem_files_creates_nested_dir_for_empty_params() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let nested = dir.path().join("export").join("q88");
+        let exporter = FpgaParameterExporter::new();
+
+        MemFileWriter::write_mem_files(&exporter, &nested).expect("write_mem_files should succeed");
+
+        for name in [
+            "parameters.mem",
+            "parameters_weights.mem",
+            "parameters_decay.mem",
+            "parameters.json",
+        ] {
+            assert!(
+                nested.join(name).is_file(),
+                "{name} should have been written"
+            );
+        }
+
+        // No parameters means empty `.mem` files, not missing ones.
+        assert!(read_hex_lines(nested.join("parameters.mem")).is_empty());
+        assert!(read_hex_lines(nested.join("parameters_weights.mem")).is_empty());
+        assert!(read_hex_lines(nested.join("parameters_decay.mem")).is_empty());
+
+        let json = fs::read_to_string(nested.join("parameters.json"))
+            .expect("parameters.json should be readable");
+        let params: FpgaParameters =
+            serde_json::from_str(&json).expect("parameters.json should deserialize");
+        assert_eq!(params.metadata.num_neurons, 0);
+        assert_eq!(params.metadata.num_channels, 0);
+        assert!((params.metadata.memory_usage_kb - 0.0).abs() < 1e-6);
+    }
 }


### PR DESCRIPTION
## **User description**
Closes #22

## What changed

Adds tempfile-based tests covering the `.mem` + metadata JSON output of `fpga_export`. Test-only change — no production code was modified, and no dependencies were added (uses the existing `tempfile` dev-dependency).

All four new tests drive the **trait path** (`MemFileWriter::write_mem_files` via UFCS, not the inherent `export_to_mem_files` wrapper), since the traits are the stable hardware-facing surface for silicon-hdl consumers.

| Test | Covers |
|---|---|
| `test_write_mem_files_via_trait_emits_expected_files` | Exact set of files written (`parameters.mem`, `parameters_weights.mem`, `parameters_decay.mem`, `parameters.json` — asserted against a sorted `read_dir` listing, so a stray file fails too); `$readmemh` line format is an uppercase 4-digit hex word (`XXXX`); expected Q8.8 words for the fixture |
| `test_mem_files_round_trip_to_parameter_export` | Re-parses the hex lines with `u16::from_str_radix` and compares against `ParameterExport::export`; decodes back through `q88_to_f32` |
| `test_metadata_json_round_trips_to_fpga_parameters` | `parameters.json` deserializes into `FpgaParameters`; vectors match `ParameterExport::export`; metadata (`version`, `num_neurons`, `num_channels`, `target_latency_us`, `memory_usage_kb`) is correct |
| `test_write_mem_files_creates_nested_dir_for_empty_params` | Edge case: an empty parameter set still creates the nested output dir and writes all four files as *empty* `.mem` files rather than omitting them |

The fixture is deliberately small and every value is a multiple of `1/256`, so Q8.8 encode/decode is lossless and the expected hex words can be asserted exactly. It includes `0.75 -> 0x00C0` specifically so the uppercase-hex assertion has a letter digit to bite on.

## Known nit (not fixed here — out of scope)

`MemFileWriter::write_mem_files` calls `print_export_summary`, which emits `println!` summary lines. Running these tests therefore produces captured stdout noise. Per REVIEW.md, `println!` in library code is a known reviewer nit (Codacy flags it; `eprintln!`/logging would be preferred), but silencing it means restructuring production code, which is outside issue #22's scope and would collide with parallel work on `src/fpga_export.rs`. Flagging it here for a follow-up rather than changing behavior in a test-only PR.

## Validation

All run locally on this branch:

| Command | Result |
|---|---|
| `cargo fmt --check` | pass (clean) |
| `cargo clippy --all-targets -- -D warnings` | pass (no warnings) |
| `cargo test` | pass — 8 unit tests (4 pre-existing + 4 new) + 1 doctest, 0 failed |
| `cargo check --features uart` | pass |

```
running 8 tests
test fpga_export::tests::test_parameter_export ... ok
test fpga_export::tests::test_q88_conversion ... ok
test fpga_export::tests::test_mem_files_round_trip_to_parameter_export ... ok
test fpga_export::tests::test_trait_surface ... ok
test fpga_export::tests::test_write_mem_files_via_trait_emits_expected_files ... ok
test fpga_export::tests::test_memory_calculation ... ok
test fpga_export::tests::test_metadata_json_round_trips_to_fpga_parameters ... ok
test fpga_export::tests::test_write_mem_files_creates_nested_dir_for_empty_params ... ok

test result: ok. 8 passed; 0 failed; 0 ignored
```

## Non-goals

Programming an FPGA; UART. Neither is touched.

## Merge note

The diff is a single contiguous block appended to the existing `#[cfg(test)] mod tests` in `src/fpga_export.rs`. No existing production code or existing tests were refactored or reformatted, to keep this mergeable alongside concurrent work on the same file (#23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tTxpWTgqUD1rEgq6m23TH


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tempfile-based tests for `fpga_export`’s `.mem` and metadata JSON outputs via the `MemFileWriter` trait path to lock down format and round‑trip correctness. Test-only change; no production code or dependencies.

- Verifies the exact file set written (`parameters.mem`, `parameters_weights.mem`, `parameters_decay.mem`, `parameters.json`) and enforces `$readmemh` line format (uppercase 4‑digit hex) using a lossless Q8.8 fixture.
- Round-trips `.mem` contents back to `ParameterExport` and validates Q8.8 decode to host floats.
- Deserializes `parameters.json` into `FpgaParameters` and checks data vectors and metadata (version, neuron/channel counts, latency, memory usage).
- Covers the empty-parameters edge case: creates nested output dir and writes empty `.mem` files rather than omitting them.
- All changes are under `#[cfg(test)]` in `src/fpga_export.rs`; running tests captures `println!` from `print_export_summary` but does not change behavior.

<sup>Written for commit 1c754ed9d6979a1ec4b11f1c43ebac777f9de683. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/silicon-bridge/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Verify FPGA memory-file and metadata exports round-trip correctly

### What Changed
- Added coverage for the complete `.mem` export bundle, including the exact output files and uppercase four-digit hexadecimal values.
- Confirmed exported memory values can be parsed back to the expected parameters without Q8.8 conversion loss.
- Confirmed metadata JSON restores parameter values and export details such as dimensions, latency, and memory usage.
- Added coverage for empty exports, including nested directory creation and empty memory files.

### Impact
`✅ Fewer FPGA export format regressions`
`✅ Reliable parameter round-trips`
`✅ Predictable empty-export files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
