### PR TITLE
docs(fpga-bridge): make the dual Q8.8 convention normative and testable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `encode_q88_unsigned` — free-function unsigned Q8.8 encoder shared by
+  `FixedPointEncode::encode_q88`, `.mem` export, and `format_q88_hex` (#23).
+- `encode_q88_signed`, `q88_signed_to_f32`, `STIMULUS_Q88_MIN`, and
+  `STIMULUS_Q88_MAX` — signed Q8.8 host-stimulus helpers used by the UART TX/RX
+  path (`uart` feature) (#23).
+
 ### Changed
 
 - License switched from GPL-3.0-or-later to dual MIT/Apache-2.0 (#6).
+- Documented the two coexisting Q8.8 conventions (unsigned `u16` export vs
+  signed `i16` UART stimuli) with a side-by-side table in the crate, module, and
+  README docs, plus tests covering both clamp boundaries (#23).

--- a/README.md
+++ b/README.md
@@ -76,14 +76,17 @@ baked into the bitstream are unsigned, host stimuli sent over UART are signed.
 | Raw type | `u16` (unsigned) | `i16` (two's complement) |
 | Width | 16 bits — 8 integer + 8 fractional | 16 bits — 8 integer + 8 fractional |
 | Scaling | `raw = value × 256`, truncated toward zero | `raw = value × 256`, truncated toward zero |
-| Input clamp | `[0.0, 255.99609375]` (scaled clamp `0..=65535`) | `[-127.99, 127.99]` |
-| Raw range | `0..=65535` | `-32765..=32765` |
+| Encoder input clamp | `[0.0, 255.99609375]` (scaled clamp `0..=65535`) | `[-127.99, 127.99]` |
+| Encoder raw output | `0..=65535` | `-32765..=32765` (saturates inside the `i16` limits) |
+| Decoder accepts | any `u16`: `0..=65535` → `0.0..=255.99609375` | any `i16`: `-32768..=32767` → `-128.0..=127.99609375` |
 | Serialized as | ASCII hex, one `{:04X}` word per line (`$readmemh`) | raw binary, big-endian (MSB first) |
 | Use it for | weights, thresholds, decay rates | host stimuli, RX membrane potentials |
 
 The export path **cannot represent negative values** — anything below `0.0`
 clamps to raw `0`, so apply your own offset/bias convention before exporting
 signed weights. Both encoders truncate toward zero and map `NaN` to raw `0`.
+The signed decoder is deliberately wider than its encoder: the FPGA may send any
+`i16`, so `0x8000` decodes to `-128.0` even though TX saturates at `±32765`.
 
 Exported `.mem` files are directly loadable by silicon-hdl `WeightRam.sv` and
 `NeuronParamRam.sv`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ back spike states at runtime.
   - `ParameterExport` — build the FPGA parameter bundle
   - `MemFileWriter` — write `$readmemh` `.mem` files
 - `FpgaParameterExporter` — default implementation of those traits
-- `format_q88_hex` / `q88_to_f32` — Q8.8 helpers
+- `format_q88_hex` / `q88_to_f32` / `encode_q88_unsigned` — unsigned Q8.8 helpers
+- `encode_q88_signed` / `q88_signed_to_f32` — signed Q8.8 stimulus helpers (`uart` feature)
 - `FpgaBridge` — UART protocol for host–FPGA spike exchange (`uart` feature)
 - `FpgaMetrics` — Vivado timing report parser (**WNS** for CI/CD gating; LUT field reserved / not parsed yet)
 
@@ -64,14 +65,28 @@ let (_potentials, spikes) = bridge.process_stimuli(&stimuli)?;
 
 ## Q8.8 Fixed-Point Format
 
-```
-Q8.8:  value = raw_u16 / 256.0
-       raw   = clamp(value × 256, 0, 65535) truncated to u16
-Range: [0, 255.996]  (unsigned)
-       [-128, 127.996]  (signed, two's complement)
-```
+Q8.8 always means "value × 256 packed into a 16-bit word", but the crate carries
+**two signedness conventions** and they are not interchangeable: parameters
+baked into the bitstream are unsigned, host stimuli sent over UART are signed.
 
-Directly loadable by silicon-hdl `WeightRam.sv` and `NeuronParamRam.sv`
+| Aspect | Parameter export (`.mem`) | Host stimuli (UART TX/RX) |
+|---|---|---|
+| Encode with | `FixedPointEncode::encode_q88` / `encode_q88_unsigned` | `encode_q88_signed` (`uart` feature) |
+| Decode with | `q88_to_f32` | `q88_signed_to_f32` (`uart` feature) |
+| Raw type | `u16` (unsigned) | `i16` (two's complement) |
+| Width | 16 bits — 8 integer + 8 fractional | 16 bits — 8 integer + 8 fractional |
+| Scaling | `raw = value × 256`, truncated toward zero | `raw = value × 256`, truncated toward zero |
+| Input clamp | `[0.0, 255.99609375]` (scaled clamp `0..=65535`) | `[-127.99, 127.99]` |
+| Raw range | `0..=65535` | `-32765..=32765` |
+| Serialized as | ASCII hex, one `{:04X}` word per line (`$readmemh`) | raw binary, big-endian (MSB first) |
+| Use it for | weights, thresholds, decay rates | host stimuli, RX membrane potentials |
+
+The export path **cannot represent negative values** — anything below `0.0`
+clamps to raw `0`, so apply your own offset/bias convention before exporting
+signed weights. Both encoders truncate toward zero and map `NaN` to raw `0`.
+
+Exported `.mem` files are directly loadable by silicon-hdl `WeightRam.sv` and
+`NeuronParamRam.sv`
 ([Limen-Neural/silicon-hdl](https://github.com/Limen-Neural/silicon-hdl)).
 
 ## Repo boundaries

--- a/src/fpga_bridge.rs
+++ b/src/fpga_bridge.rs
@@ -5,10 +5,74 @@
 //! and read back spike states using the SiliconBridge v3.0 protocol.
 //!
 //! Extracted from Eagle-Lander's Ship of Theseus neuromorphic core.
+//!
+//! ## Q8.8 convention used here: signed
+//!
+//! Host stimuli and membrane potentials on the wire are **signed** Q8.8 (`i16`,
+//! two's complement, big-endian). This is *not* the convention used by the
+//! parameter export path (`fpga_export`), which is unsigned `u16` written as
+//! ASCII hex. Encoding a stimulus with the export encoder would turn every
+//! negative (inhibitory) input into `0`; decoding a potential with the export
+//! decoder would read negatives as large positives.
+//!
+//! | Aspect | This module (UART TX/RX) | `fpga_export` (`.mem`) |
+//! |---|---|---|
+//! | Encode with | [`encode_q88_signed`] | `encode_q88_unsigned` |
+//! | Decode with | [`q88_signed_to_f32`] | `q88_to_f32` |
+//! | Raw type | `i16` (two's complement) | `u16` (unsigned) |
+//! | Width | 16 bits — 8 integer + 8 fractional | 16 bits — 8 integer + 8 fractional |
+//! | Input clamp | [`STIMULUS_Q88_MIN`]`..=`[`STIMULUS_Q88_MAX`] (`-127.99..=127.99`) | `0.0..=255.99609375` |
+//! | Raw range | `-32765..=32765` | `0..=65535` |
+//! | Byte order | raw binary, big-endian (MSB first) | ASCII hex, one `{:04X}` word per line |
+//! | Use it for | host stimuli, RX membrane potentials | weights, thresholds, decay rates |
+//!
+//! The crate root docs carry the same table as the canonical reference.
 
 use serialport::{SerialPort, SerialPortInfo};
 use std::io::{Read, Write};
 use std::time::Duration;
+
+/// Lower clamp bound for host stimuli on the signed Q8.8 UART path.
+///
+/// Values below this saturate to raw `-32765` on the wire.
+pub const STIMULUS_Q88_MIN: f32 = -127.99;
+
+/// Upper clamp bound for host stimuli on the signed Q8.8 UART path.
+///
+/// Values above this saturate to raw `32765` on the wire.
+pub const STIMULUS_Q88_MAX: f32 = 127.99;
+
+/// Encode a host stimulus as **signed** Q8.8 (`i16`, two's complement).
+///
+/// `raw = value × 256`, truncated toward zero, with the input clamped to
+/// [`STIMULUS_Q88_MIN`]`..=`[`STIMULUS_Q88_MAX`]. `NaN` encodes as `0`. The
+/// wire format is big-endian, so callers serialize with `to_be_bytes()`.
+///
+/// This is the stimulus counterpart of the crate's unsigned `encode_q88_unsigned`
+/// used for `.mem` parameter export — the two are **not** interchangeable.
+///
+/// ```rust
+/// use silicon_bridge::{encode_q88_signed, q88_signed_to_f32};
+///
+/// assert_eq!(encode_q88_signed(1.0), 256);
+/// assert_eq!(encode_q88_signed(-1.0), -256); // negatives survive here
+/// assert_eq!(encode_q88_signed(-1.0).to_be_bytes(), [0xFF, 0x00]);
+/// assert_eq!(q88_signed_to_f32(encode_q88_signed(-0.5)), -0.5);
+/// ```
+pub fn encode_q88_signed(value: f32) -> i16 {
+    // ENCODE SITE (signed Q8.8) — this is the UART / host-stimulus path.
+    // Clamp happens on the *unscaled* value, so saturation lands on raw
+    // ±32765 (±127.99 × 256, truncated) rather than the i16 limits.
+    (value.clamp(STIMULUS_Q88_MIN, STIMULUS_Q88_MAX) * 256.0) as i16
+}
+
+/// Decode a **signed** Q8.8 (`i16`) wire word back to `f32`.
+///
+/// Counterpart of [`encode_q88_signed`]. For `.mem` parameter words use the
+/// crate's unsigned `q88_to_f32` instead.
+pub fn q88_signed_to_f32(raw: i16) -> f32 {
+    raw as f32 / 256.0
+}
 
 pub struct FpgaBridge {
     port: Box<dyn SerialPort>,
@@ -40,8 +104,12 @@ impl FpgaBridge {
     /// Send neural stimuli to FPGA and read back spike states.
     ///
     /// Protocol (16-neuron SiliconBridge v3.0):
-    ///   TX: 0xAA + 32 bytes (16 × Q8.8 stimuli)
-    ///   RX: 32 bytes (16 × Q8.8 potentials) + 2 bytes (spike flags) + 2 bytes (switches)
+    ///   TX: 0xAA + 32 bytes (16 × signed Q8.8 stimuli, big-endian)
+    ///   RX: 32 bytes (16 × signed Q8.8 potentials) + 2 bytes (spike flags) + 2 bytes (switches)
+    ///
+    /// Stimuli are encoded with [`encode_q88_signed`] (`i16`, clamped to
+    /// [`STIMULUS_Q88_MIN`]`..=`[`STIMULUS_Q88_MAX`]) — **not** with the
+    /// unsigned `.mem` export encoder.
     ///
     /// Input is accepted as a dynamic slice; if fewer than 16 values are provided,
     /// remaining channels are zero-padded. If more are provided, only the first 16 are sent.
@@ -53,11 +121,13 @@ impl FpgaBridge {
             return Err("FPGA bridge not active".into());
         }
 
-        // Convert stimuli to Q8.8 format (16-bit fixed point)
+        // Convert stimuli to SIGNED Q8.8 (i16), big-endian on the wire.
+        // Note this is the signed convention, not the unsigned `u16` one used
+        // by `fpga_export` for `.mem` files — see this module's docs.
         let mut tx_data = vec![0xAAu8]; // Sync byte
         for i in 0..16 {
             let s = stimuli.get(i).copied().unwrap_or(0.0);
-            let q8_8 = (s.clamp(-127.99, 127.99) * 256.0) as i16;
+            let q8_8 = encode_q88_signed(s);
             tx_data.extend_from_slice(&q8_8.to_be_bytes());
         }
 
@@ -69,11 +139,12 @@ impl FpgaBridge {
         let mut rx_data = vec![0u8; 36];
         self.port.read_exact(&mut rx_data)?;
 
-        // Parse potentials (Q8.8 back to f32)
+        // Parse potentials (signed Q8.8 big-endian back to f32) — membrane
+        // potentials can be negative, hence `i16` rather than the export `u16`.
         let mut potentials = Vec::with_capacity(16);
         for i in 0..16 {
             let raw = i16::from_be_bytes([rx_data[i * 2], rx_data[i * 2 + 1]]);
-            potentials.push(raw as f32 / 256.0);
+            potentials.push(q88_signed_to_f32(raw));
         }
 
         // Parse spike flags (16-bit, 1 per neuron)
@@ -110,5 +181,108 @@ pub fn find_fpga_ports() -> Vec<SerialPortInfo> {
             .filter(|p| p.port_name.contains("ttyUSB"))
             .collect(),
         Err(_) => Vec::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Q8.8 convention tests (signed UART path). This whole module is compiled only
+// with the `uart` feature, so these tests are feature-gated by construction.
+// The unsigned export counterpart is tested in `fpga_export`.
+// ---------------------------------------------------------------------------
+#[cfg(all(test, feature = "uart"))]
+mod q88_signed_convention_tests {
+    use super::*;
+    use crate::{encode_q88_unsigned, q88_to_f32};
+
+    #[test]
+    fn signed_encode_scales_by_256_in_both_directions() {
+        assert_eq!(encode_q88_signed(0.0), 0);
+        assert_eq!(encode_q88_signed(1.0), 256);
+        assert_eq!(encode_q88_signed(-1.0), -256);
+        assert_eq!(encode_q88_signed(0.5), 128);
+        assert_eq!(encode_q88_signed(-0.5), -128);
+        assert_eq!(encode_q88_signed(1.0 / 256.0), 1); // one LSB
+        assert_eq!(encode_q88_signed(-1.0 / 256.0), -1);
+    }
+
+    #[test]
+    fn signed_encode_truncates_toward_zero() {
+        assert_eq!(encode_q88_signed(0.999), 255);
+        assert_eq!(encode_q88_signed(-0.999), -255);
+    }
+
+    #[test]
+    fn signed_encode_clamps_at_both_ends() {
+        // Saturation lands on +/-32765 (+/-127.99 x 256 truncated), inside the
+        // i16 limits, so the range is symmetric.
+        assert_eq!(encode_q88_signed(STIMULUS_Q88_MAX), 32765);
+        assert_eq!(encode_q88_signed(STIMULUS_Q88_MIN), -32765);
+        assert_eq!(encode_q88_signed(128.0), 32765);
+        assert_eq!(encode_q88_signed(-128.0), -32765);
+        assert_eq!(encode_q88_signed(1.0e6), 32765);
+        assert_eq!(encode_q88_signed(-1.0e6), -32765);
+        assert_eq!(encode_q88_signed(f32::MAX), 32765);
+        assert_eq!(encode_q88_signed(f32::MIN), -32765);
+        assert_eq!(encode_q88_signed(f32::INFINITY), 32765);
+        assert_eq!(encode_q88_signed(f32::NEG_INFINITY), -32765);
+    }
+
+    #[test]
+    fn signed_encode_maps_nan_to_zero() {
+        assert_eq!(encode_q88_signed(f32::NAN), 0);
+    }
+
+    #[test]
+    fn signed_wire_words_are_big_endian() {
+        // TX serializes with `to_be_bytes()`: most significant byte first.
+        assert_eq!(encode_q88_signed(1.0).to_be_bytes(), [0x01, 0x00]);
+        assert_eq!(encode_q88_signed(-1.0).to_be_bytes(), [0xFF, 0x00]);
+        assert_eq!(encode_q88_signed(-0.5).to_be_bytes(), [0xFF, 0x80]);
+        assert_eq!(
+            encode_q88_signed(STIMULUS_Q88_MAX).to_be_bytes(),
+            [0x7F, 0xFD]
+        );
+    }
+
+    #[test]
+    fn signed_encode_round_trips_through_q88_signed_to_f32() {
+        for value in [-127.0_f32, -12.25, -1.0, -0.00390625, 0.0, 0.5, 64.75] {
+            let raw = encode_q88_signed(value);
+            assert_eq!(
+                q88_signed_to_f32(raw),
+                value,
+                "round trip failed for {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn signed_and_unsigned_agree_only_on_the_shared_range() {
+        // Non-negative inputs up to the signed clamp encode to the same raw bits.
+        for value in [0.0_f32, 0.5, 1.0, 64.25, 127.0] {
+            assert_eq!(
+                i32::from(encode_q88_signed(value)),
+                i32::from(encode_q88_unsigned(value)),
+                "conventions should agree for {value}"
+            );
+        }
+
+        // Above the signed clamp the two diverge: the export path keeps scaling.
+        assert_eq!(encode_q88_signed(200.0), 32765);
+        assert_eq!(encode_q88_unsigned(200.0), 51200);
+    }
+
+    #[test]
+    fn using_the_wrong_convention_corrupts_negative_values() {
+        // This is the whole point of keeping the two encoders distinct: an
+        // inhibitory stimulus survives the signed path and is lost on the
+        // unsigned one, and a signed wire word decoded as unsigned reads as a
+        // large positive value.
+        assert_eq!(encode_q88_signed(-1.0), -256);
+        assert_eq!(encode_q88_unsigned(-1.0), 0);
+
+        let wire = encode_q88_signed(-1.0);
+        assert_eq!(q88_signed_to_f32(wire), -1.0);
+        assert_eq!(q88_to_f32(wire as u16), 255.0);
     }
 }

--- a/src/fpga_bridge.rs
+++ b/src/fpga_bridge.rs
@@ -21,8 +21,9 @@
 //! | Decode with | [`q88_signed_to_f32`] | `q88_to_f32` |
 //! | Raw type | `i16` (two's complement) | `u16` (unsigned) |
 //! | Width | 16 bits — 8 integer + 8 fractional | 16 bits — 8 integer + 8 fractional |
-//! | Input clamp | [`STIMULUS_Q88_MIN`]`..=`[`STIMULUS_Q88_MAX`] (`-127.99..=127.99`) | `0.0..=255.99609375` |
-//! | Raw range | `-32765..=32765` | `0..=65535` |
+//! | Encoder input clamp | [`STIMULUS_Q88_MIN`]`..=`[`STIMULUS_Q88_MAX`] (`-127.99..=127.99`) | `0.0..=255.99609375` |
+//! | Encoder raw output | `-32765..=32765` (TX saturation) | `0..=65535` |
+//! | Decoder accepts | any `i16`: `-32768..=32767` → `-128.0..=127.99609375` | any `u16`: `0..=65535` |
 //! | Byte order | raw binary, big-endian (MSB first) | ASCII hex, one `{:04X}` word per line |
 //! | Use it for | host stimuli, RX membrane potentials | weights, thresholds, decay rates |
 //!
@@ -68,8 +69,12 @@ pub fn encode_q88_signed(value: f32) -> i16 {
 
 /// Decode a **signed** Q8.8 (`i16`) wire word back to `f32`.
 ///
-/// Counterpart of [`encode_q88_signed`]. For `.mem` parameter words use the
-/// crate's unsigned `q88_to_f32` instead.
+/// Counterpart of [`encode_q88_signed`], but deliberately wider: every `i16` the
+/// FPGA can send is valid, so this covers `-32768..=32767`
+/// (`-128.0..=127.99609375`) — including the two words just outside what
+/// [`encode_q88_signed`] can produce (it saturates at `±32765`).
+///
+/// For `.mem` parameter words use the crate's unsigned `q88_to_f32` instead.
 pub fn q88_signed_to_f32(raw: i16) -> f32 {
     raw as f32 / 256.0
 }
@@ -109,7 +114,9 @@ impl FpgaBridge {
     ///
     /// Stimuli are encoded with [`encode_q88_signed`] (`i16`, clamped to
     /// [`STIMULUS_Q88_MIN`]`..=`[`STIMULUS_Q88_MAX`]) — **not** with the
-    /// unsigned `.mem` export encoder.
+    /// unsigned `.mem` export encoder. RX potentials are decoded with
+    /// [`q88_signed_to_f32`] over the full `i16` range, which is wider than what
+    /// the TX encoder can emit.
     ///
     /// Input is accepted as a dynamic slice; if fewer than 16 values are provided,
     /// remaining channels are zero-padded. If more are provided, only the first 16 are sent.
@@ -254,6 +261,17 @@ mod q88_signed_convention_tests {
                 "round trip failed for {value}"
             );
         }
+    }
+
+    #[test]
+    fn signed_decoder_covers_the_full_i16_wire_range() {
+        // The encoder saturates at +/-32765, but the FPGA may send any i16, so
+        // the decoder must accept the two words just outside that range.
+        assert_eq!(q88_signed_to_f32(i16::MIN), -128.0);
+        assert_eq!(q88_signed_to_f32(i16::MAX), 32767.0 / 256.0);
+        assert_eq!(q88_signed_to_f32(-32766), -32766.0 / 256.0);
+        assert!(encode_q88_signed(-128.0) > i16::MIN);
+        assert!(encode_q88_signed(f32::MAX) < i16::MAX);
     }
 
     #[test]

--- a/src/fpga_export.rs
+++ b/src/fpga_export.rs
@@ -26,8 +26,9 @@
 //! | Raw type | `u16` (unsigned — negatives are **not** representable) |
 //! | Width | 16 bits — 8 integer + 8 fractional |
 //! | Scaling | `raw = value × 256`, truncated toward zero |
-//! | Input clamp | `[0.0, 255.99609375]` (scaled clamp `0..=65535`) |
-//! | Raw range | `0..=65535` |
+//! | Encoder input clamp | `[0.0, 255.99609375]` (scaled clamp `0..=65535`) |
+//! | Encoder raw output | `0..=65535` |
+//! | Decoder accepts | any `u16`: `0..=65535` → `0.0..=255.99609375` |
 //! | Serialized as | ASCII hex text, one `{:04X}` word per line for `$readmemh` |
 //! | Use it for | weights, thresholds, decay rates |
 //!

--- a/src/fpga_export.rs
+++ b/src/fpga_export.rs
@@ -13,6 +13,26 @@
 //! - [`FixedPointEncode`] — `f32` → Q8.8 `u16`
 //! - [`ParameterExport`] — produce [`FpgaParameters`]
 //! - [`MemFileWriter`] — write `.mem` + metadata JSON
+//!
+//! ## Q8.8 convention used here: unsigned
+//!
+//! Everything in this module encodes **unsigned** Q8.8. The UART bridge
+//! (`fpga_bridge`, `uart` feature) uses a *different*, signed convention for
+//! host stimuli; see the "Q8.8 conventions" table in the crate root docs for the
+//! full side-by-side comparison.
+//!
+//! | Aspect | This module (`.mem` export) |
+//! |---|---|
+//! | Raw type | `u16` (unsigned — negatives are **not** representable) |
+//! | Width | 16 bits — 8 integer + 8 fractional |
+//! | Scaling | `raw = value × 256`, truncated toward zero |
+//! | Input clamp | `[0.0, 255.99609375]` (scaled clamp `0..=65535`) |
+//! | Raw range | `0..=65535` |
+//! | Serialized as | ASCII hex text, one `{:04X}` word per line for `$readmemh` |
+//! | Use it for | weights, thresholds, decay rates |
+//!
+//! Use [`encode_q88_unsigned`] (or [`FixedPointEncode::encode_q88`]) for
+//! parameters, and `encode_q88_signed` from the `uart` feature for host stimuli.
 
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -29,8 +49,16 @@ pub const EXPORT_FORMAT_VERSION: &str = "Spikenaut-v2";
 ///
 /// Q8.8 maps `value × 256` into a 16-bit word. Values outside the representable
 /// range are clamped.
+///
+/// This is the **unsigned** convention (`0.0..=255.99609375`, raw `0..=65535`)
+/// used for `.mem` parameter export. Host stimuli sent over UART use the signed
+/// `i16` convention instead (`encode_q88_signed`, `uart` feature) — see the
+/// "Q8.8 conventions" table in the crate root docs.
 pub trait FixedPointEncode {
-    /// Convert one `f32` to Q8.8 fixed-point.
+    /// Convert one `f32` to unsigned Q8.8 fixed-point.
+    ///
+    /// Negative inputs clamp to `0`; inputs above `255.99609375` clamp to
+    /// `65535`; `NaN` encodes as `0`.
     fn encode_q88(&self, value: f32) -> u16;
 }
 
@@ -199,10 +227,11 @@ impl FpgaParameterExporter {
 
 impl FixedPointEncode for FpgaParameterExporter {
     fn encode_q88(&self, value: f32) -> u16 {
-        // Q8.8: 8 integer bits, 8 fractional bits
-        // Range: 0.0 to 255.996 (clamped into u16)
-        let scaled = value * 256.0;
-        scaled.clamp(0.0, 65535.0) as u16
+        // ENCODE SITE (unsigned Q8.8) — this is the `.mem` / synthesis path.
+        // Q8.8: 8 integer bits, 8 fractional bits, range 0.0..=255.99609375.
+        // Negative values are NOT representable here and clamp to 0; the signed
+        // `i16` convention lives in `fpga_bridge::encode_q88_signed` (`uart`).
+        encode_q88_unsigned(value)
     }
 }
 
@@ -286,6 +315,32 @@ impl Default for FpgaParameterExporter {
     }
 }
 
+/// Encode an `f32` as **unsigned** Q8.8 (`u16`) without needing an exporter.
+///
+/// This is the single source of truth for the export-path encoding used by
+/// [`FixedPointEncode::encode_q88`], `.mem` files, and [`format_q88_hex`]:
+/// `raw = value × 256`, truncated toward zero, with the scaled result clamped
+/// into `0..=65535`.
+///
+/// Host stimuli sent over UART must **not** use this function — they use the
+/// signed `i16` convention (`encode_q88_signed`, `uart` feature). See the
+/// "Q8.8 conventions" table in the crate root docs.
+///
+/// ```rust
+/// use silicon_bridge::{encode_q88_unsigned, q88_to_f32};
+///
+/// assert_eq!(encode_q88_unsigned(1.0), 256);
+/// assert_eq!(encode_q88_unsigned(-1.0), 0); // no negatives on the export path
+/// assert_eq!(encode_q88_unsigned(1000.0), 65535); // saturates
+/// assert_eq!(q88_to_f32(encode_q88_unsigned(0.5)), 0.5);
+/// ```
+pub fn encode_q88_unsigned(value: f32) -> u16 {
+    // ENCODE SITE (unsigned Q8.8) — clamp happens on the *scaled* value, so the
+    // representable input range is 0.0..=255.99609375 (65535 / 256).
+    let scaled = value * 256.0;
+    scaled.clamp(0.0, 65535.0) as u16
+}
+
 /// Helper function to format Q8.8 value as hex string
 pub fn format_q88_hex(value: f32) -> String {
     let exporter = FpgaParameterExporter::new();
@@ -293,7 +348,11 @@ pub fn format_q88_hex(value: f32) -> String {
     format!("{:04X}", q88_value)
 }
 
-/// Helper function to convert Q8.8 back to f32
+/// Helper function to convert **unsigned** Q8.8 back to f32.
+///
+/// Counterpart of [`encode_q88_unsigned`]. For the signed UART path use
+/// `q88_signed_to_f32` (`uart` feature) instead — decoding a signed raw word
+/// with this function reads negatives as large positives.
 pub fn q88_to_f32(q88_value: u16) -> f32 {
     q88_value as f32 / 256.0
 }
@@ -375,5 +434,98 @@ mod tests {
         assert_eq!(params.thresholds, vec![256]);
         assert_eq!(params.weights, vec![128]);
         assert_eq!(params.decay_rates, vec![230]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Q8.8 convention tests (unsigned export path). The signed UART counterpart
+// lives in `fpga_bridge` behind the `uart` feature; see the "Q8.8 conventions"
+// table in the crate root docs.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod q88_unsigned_convention_tests {
+    use super::*;
+
+    /// Largest input the unsigned export path can represent: 65535 / 256.
+    const MAX_UNSIGNED_INPUT: f32 = 65535.0 / 256.0; // 255.99609375
+
+    #[test]
+    fn unsigned_encode_scales_by_256() {
+        assert_eq!(encode_q88_unsigned(0.0), 0);
+        assert_eq!(encode_q88_unsigned(1.0), 256);
+        assert_eq!(encode_q88_unsigned(0.5), 128);
+        assert_eq!(encode_q88_unsigned(1.0 / 256.0), 1); // one LSB
+        assert_eq!(encode_q88_unsigned(255.0), 65280);
+    }
+
+    #[test]
+    fn unsigned_encode_truncates_toward_zero() {
+        // 0.999 x 256 = 255.744 -> 255 (truncated, not rounded up to 256)
+        assert_eq!(encode_q88_unsigned(0.999), 255);
+        assert_eq!(encode_q88_unsigned(1.9999), 511);
+    }
+
+    #[test]
+    fn unsigned_encode_clamps_at_both_ends() {
+        // Upper boundary: 65535 / 256 is the largest representable input.
+        assert_eq!(encode_q88_unsigned(MAX_UNSIGNED_INPUT), 65535);
+        assert_eq!(encode_q88_unsigned(256.0), 65535);
+        assert_eq!(encode_q88_unsigned(1.0e6), 65535);
+        assert_eq!(encode_q88_unsigned(f32::MAX), 65535);
+        assert_eq!(encode_q88_unsigned(f32::INFINITY), 65535);
+
+        // Lower boundary: the export path cannot represent negatives at all.
+        assert_eq!(encode_q88_unsigned(0.0), 0);
+        assert_eq!(encode_q88_unsigned(-1.0 / 256.0), 0);
+        assert_eq!(encode_q88_unsigned(-1.0), 0);
+        assert_eq!(encode_q88_unsigned(-127.99), 0);
+        assert_eq!(encode_q88_unsigned(f32::MIN), 0);
+        assert_eq!(encode_q88_unsigned(f32::NEG_INFINITY), 0);
+    }
+
+    #[test]
+    fn unsigned_encode_maps_nan_to_zero() {
+        assert_eq!(encode_q88_unsigned(f32::NAN), 0);
+    }
+
+    #[test]
+    fn unsigned_encode_round_trips_through_q88_to_f32() {
+        for value in [0.0_f32, 0.00390625, 0.5, 1.0, 12.25, MAX_UNSIGNED_INPUT] {
+            let raw = encode_q88_unsigned(value);
+            assert_eq!(q88_to_f32(raw), value, "round trip failed for {value}");
+        }
+    }
+
+    #[test]
+    fn trait_and_inherent_encoders_match_the_free_function() {
+        let exporter = FpgaParameterExporter::new();
+        for value in [-5.0_f32, 0.0, 0.3, 1.0, 255.0, 300.0] {
+            let expected = encode_q88_unsigned(value);
+            assert_eq!(FixedPointEncode::encode_q88(&exporter, value), expected);
+            assert_eq!(exporter.to_q88(value), expected);
+        }
+    }
+
+    #[test]
+    fn mem_words_are_four_hex_digits_msb_first() {
+        // `.mem` files carry ASCII hex, one 4-digit word per line for $readmemh.
+        assert_eq!(format_q88_hex(0.0), "0000");
+        assert_eq!(format_q88_hex(1.0), "0100");
+        assert_eq!(format_q88_hex(MAX_UNSIGNED_INPUT), "FFFF");
+        assert_eq!(format_q88_hex(-1.0), "0000"); // clamped, not two's complement
+    }
+
+    #[test]
+    fn exported_vectors_clamp_out_of_range_parameters() {
+        let exporter = FpgaParameterExporter::from_params(
+            vec![-1.0, 300.0],
+            vec![vec![-0.5, 1.0]],
+            vec![0.0, MAX_UNSIGNED_INPUT],
+        );
+        let params = ParameterExport::export(&exporter);
+
+        assert_eq!(params.thresholds, vec![0, 65535]);
+        assert_eq!(params.weights, vec![0, 256]);
+        assert_eq!(params.decay_rates, vec![0, 65535]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,9 @@
 //! | Raw type | `u16` (unsigned) | `i16` (two's complement) |
 //! | Width | 16 bits — 8 integer + 8 fractional | 16 bits — 8 integer + 8 fractional |
 //! | Scaling | `raw = value × 256`, truncated toward zero | `raw = value × 256`, truncated toward zero |
-//! | Input clamp | `[0.0, 255.99609375]` (scaled clamp `0..=65535`) | `[-127.99, 127.99]` |
-//! | Raw range | `0..=65535` | `-32765..=32765` |
+//! | Encoder input clamp | `[0.0, 255.99609375]` (scaled clamp `0..=65535`) | `[-127.99, 127.99]` |
+//! | Encoder raw output | `0..=65535` | `-32765..=32765` (saturates inside the `i16` limits) |
+//! | Decoder accepts | any `u16`: `0..=65535` → `0.0..=255.99609375` | any `i16`: `-32768..=32767` → `-128.0..=127.99609375` |
 //! | Serialized as | ASCII hex text, one `{:04X}` word per line (`$readmemh`) | raw binary, big-endian (MSB first) |
 //! | Consumed by | silicon-hdl `WeightRam` / `NeuronParamRam` | SiliconBridge v3.0 UART frame |
 //! | Use it for | weights, thresholds, decay rates | host stimuli, RX membrane potentials |
@@ -37,8 +38,10 @@
 //! - The export path **cannot represent negative values**; anything below `0.0`
 //!   clamps to raw `0`. Apply your own offset/bias convention before export if
 //!   trained weights can be negative.
-//! - The signed path saturates at raw `±32765` (`±127.99 × 256`, truncated), not
-//!   at the `i16` limits, so both ends of the range are symmetric.
+//! - The signed *encoder* saturates at raw `±32765` (`±127.99 × 256`, truncated),
+//!   inside the `i16` limits, so both ends of the TX range are symmetric. The
+//!   *decoder* is wider on purpose: an FPGA response of `0x8000` legitimately
+//!   decodes to `-128.0` and `0x7FFF` to `127.99609375`.
 //! - Both encoders truncate toward zero rather than rounding, and both map `NaN`
 //!   to raw `0`.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,36 @@
 //!
 //! Licensed under either of MIT or Apache-2.0 at your option.
 //!
+//! ## Q8.8 conventions
+//!
+//! Q8.8 always means "value × 256 packed into a 16-bit word", but this crate
+//! carries **two different signedness conventions** and they are not
+//! interchangeable. Parameters baked into the bitstream are unsigned; host
+//! stimuli pushed over UART are signed two's complement.
+//!
+//! | Aspect | Parameter export (`.mem`) | Host stimuli (UART TX/RX) |
+//! |---|---|---|
+//! | Encode with | [`FixedPointEncode::encode_q88`] / [`encode_q88_unsigned`] | `encode_q88_signed` (`uart` feature) |
+//! | Decode with | [`q88_to_f32`] | `q88_signed_to_f32` (`uart` feature) |
+//! | Raw type | `u16` (unsigned) | `i16` (two's complement) |
+//! | Width | 16 bits — 8 integer + 8 fractional | 16 bits — 8 integer + 8 fractional |
+//! | Scaling | `raw = value × 256`, truncated toward zero | `raw = value × 256`, truncated toward zero |
+//! | Input clamp | `[0.0, 255.99609375]` (scaled clamp `0..=65535`) | `[-127.99, 127.99]` |
+//! | Raw range | `0..=65535` | `-32765..=32765` |
+//! | Serialized as | ASCII hex text, one `{:04X}` word per line (`$readmemh`) | raw binary, big-endian (MSB first) |
+//! | Consumed by | silicon-hdl `WeightRam` / `NeuronParamRam` | SiliconBridge v3.0 UART frame |
+//! | Use it for | weights, thresholds, decay rates | host stimuli, RX membrane potentials |
+//!
+//! Consequences worth remembering:
+//!
+//! - The export path **cannot represent negative values**; anything below `0.0`
+//!   clamps to raw `0`. Apply your own offset/bias convention before export if
+//!   trained weights can be negative.
+//! - The signed path saturates at raw `±32765` (`±127.99 × 256`, truncated), not
+//!   at the `i16` limits, so both ends of the range are symmetric.
+//! - Both encoders truncate toward zero rather than rounding, and both map `NaN`
+//!   to raw `0`.
+//!
 //! ## Provenance
 //!
 //! Extracted from Eagle-Lander, the author's own private neuromorphic GPU supervisor
@@ -48,10 +78,13 @@ mod fpga_bridge;
 // Re-export public API
 pub use fpga_export::{
     EXPORT_FORMAT_VERSION, FixedPointEncode, FpgaMetadata, FpgaParameterExporter, FpgaParameters,
-    MemFileWriter, ParameterExport, format_q88_hex, q88_to_f32,
+    MemFileWriter, ParameterExport, encode_q88_unsigned, format_q88_hex, q88_to_f32,
 };
 
 pub use fpga_metrics::FpgaMetrics;
 
 #[cfg(feature = "uart")]
-pub use fpga_bridge::{FpgaBridge, find_fpga_ports};
+pub use fpga_bridge::{
+    FpgaBridge, STIMULUS_Q88_MAX, STIMULUS_Q88_MIN, encode_q88_signed, find_fpga_ports,
+    q88_signed_to_f32,
+};


### PR DESCRIPTION
## **User description**
Closes #23

## Problem

Two Q8.8 conventions coexist in this crate and the public API did not make the split obvious:

- **Export path** (`FixedPointEncode` / `.mem`, `src/fpga_export.rs`): unsigned `u16`, `value × 256`, scaled clamp `0..=65535`, written as ASCII hex for `$readmemh`.
- **UART TX/RX** (`FpgaBridge::process_stimuli`, `src/fpga_bridge.rs`, `uart` feature): signed `i16` two's complement, input clamped to `[-127.99, 127.99]`, big-endian on the wire.

Mixing them silently corrupts data: an inhibitory (negative) stimulus encoded with the export encoder becomes `0`, and a signed wire word decoded as unsigned reads as a large positive.

## What changed

**Docs (normative)**

- Side-by-side conventions table in the crate root rustdoc (`src/lib.rs`) — signedness, width, scaling, input clamp, raw range, serialization/byte order, consumer, and which one to use for weights vs. host stimuli.
- Per-module table in `fpga_export` (unsigned) and `fpga_bridge` (signed), each pointing at the crate-root table as the canonical reference.
- Same table mirrored in `README.md`, replacing the old code block that listed both ranges without saying which path used which.
- `process_stimuli` protocol doc now says "signed Q8.8, big-endian".

**Code comments at each encode site**

- `FixedPointEncode::encode_q88` and `encode_q88_unsigned` — unsigned, negatives not representable.
- `encode_q88_signed` and the `process_stimuli` TX/RX loops — signed, clamp on the unscaled value, big-endian.

**Small non-breaking API clarity** (as suggested in the issue)

- `encode_q88_unsigned(f32) -> u16` — free-function encoder, now the single source of truth for the export path; `FixedPointEncode::encode_q88` delegates to it (logic unchanged).
- `encode_q88_signed(f32) -> i16` and `q88_signed_to_f32(i16) -> f32` plus `STIMULUS_Q88_MIN` / `STIMULUS_Q88_MAX` (`uart` feature) — the stimulus helpers `process_stimuli` now calls, which also makes the signed path testable without hardware.

No existing public signature changed; everything is additive. CHANGELOG updated.

**Tests (both conventions, both clamp ends)**

- `src/fpga_export.rs` → new `mod q88_unsigned_convention_tests` (kept as a separate block so it merges cleanly with the parallel `MemFileWriter` work in #22): scaling, truncation toward zero, upper clamp (`65535/256`, `256.0`, `f32::MAX`, `INFINITY`), lower clamp (negatives, `f32::MIN`, `NEG_INFINITY`), `NaN → 0`, round-trip through `q88_to_f32`, trait/inherent/free-function agreement, `.mem` hex word format, and clamping through `ParameterExport::export`.
- `src/fpga_bridge.rs` → new `mod q88_signed_convention_tests`, gated `#[cfg(all(test, feature = "uart"))]`: symmetric scaling, truncation toward zero for negatives, saturation at `±32765` at both ends, `NaN → 0`, big-endian `to_be_bytes()` layout, round-trip through `q88_signed_to_f32`, agreement between the two encoders on the shared range, and an explicit test that using the wrong convention corrupts negative values.

Test count: 12 → 20 unit tests (with `uart`), 2 → 3 doctests.

## Validation

| Command | Result |
|---|---|
| `cargo fmt --check` | pass (no output) |
| `cargo clippy --all-targets -- -D warnings` | pass, no warnings |
| `cargo test` | pass — 12 unit tests, 2 doctests |
| `cargo check --features uart` | pass |
| `cargo test --features uart` | pass — 20 unit tests, 3 doctests |
| `cargo clippy --all-targets --features uart -- -D warnings` | pass, no warnings |
| `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (with and without `uart`) | pass — no broken intra-doc links |

## Non-goals

No change to the silicon-hdl wire protocol (byte layout, clamp values, and encoded results are bit-identical to before) and nothing NIR-related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tTxpWTgqUD1rEgq6m23TH


___

## **CodeAnt-AI Description**
Separate unsigned parameter encoding from signed UART stimulus encoding

### What Changed
- FPGA parameter exports continue using unsigned Q8.8 values, while UART stimuli and membrane potentials now use signed two’s-complement Q8.8 values.
- Negative host stimuli are preserved over UART instead of being converted to zero, and negative FPGA responses are decoded correctly.
- Added public helpers and range constants for both encoding conventions, including clamping, truncation, NaN handling, and big-endian wire behavior.
- Documented the two formats side by side in the crate, module documentation, README, and changelog.
- Added coverage for boundary values, wire order, round trips, `.mem` output, and incorrect convention usage.

### Impact
`✅ Negative stimuli reach the FPGA intact`
`✅ Negative membrane potentials are reported correctly`
`✅ Fewer Q8.8 format mix-ups`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
