### PR TITLE
test(fpga-export): MemFileWriter .mem + metadata JSON tests

### DIFF
--- a/src/fpga_export.rs
+++ b/src/fpga_export.rs
@@ -464,9 +464,7 @@ mod tests {
 
         let expected = ParameterExport::export(&exporter);
         let thresholds = parse_mem_words(&read_mem_lines(dir.path().join("parameters.mem")));
-        let weights = parse_mem_words(&read_mem_lines(
-            dir.path().join("parameters_weights.mem"),
-        ));
+        let weights = parse_mem_words(&read_mem_lines(dir.path().join("parameters_weights.mem")));
         let decay_rates = parse_mem_words(&read_mem_lines(dir.path().join("parameters_decay.mem")));
 
         assert_eq!(thresholds, expected.thresholds);

--- a/src/fpga_export.rs
+++ b/src/fpga_export.rs
@@ -376,4 +376,134 @@ mod tests {
         assert_eq!(params.weights, vec![128]);
         assert_eq!(params.decay_rates, vec![230]);
     }
+
+    /// Small fixture whose floats are exact Q8.8 multiples of 1/256.
+    fn mem_writer_fixture() -> FpgaParameterExporter {
+        FpgaParameterExporter::from_params(
+            vec![1.0, 0.75],
+            vec![vec![0.5, 2.0], vec![0.25, 1.5]],
+            vec![0.5, 0.75],
+        )
+    }
+
+    fn read_mem_lines(path: impl AsRef<Path>) -> Vec<String> {
+        fs::read_to_string(path)
+            .expect("mem file should be readable")
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn assert_uppercase_hex_words(lines: &[String]) {
+        for line in lines {
+            assert_eq!(line.len(), 4, "expected XXXX hex word, got {line:?}");
+            assert!(
+                line.chars()
+                    .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_lowercase()),
+                "expected uppercase XXXX hex word, got {line:?}"
+            );
+        }
+    }
+
+    fn parse_mem_words(lines: &[String]) -> Vec<u16> {
+        lines
+            .iter()
+            .map(|line| u16::from_str_radix(line, 16).expect("mem line should be valid hex"))
+            .collect()
+    }
+
+    #[test]
+    fn test_write_mem_files_via_trait_emits_expected_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let exporter = mem_writer_fixture();
+
+        MemFileWriter::write_mem_files(&exporter, dir.path()).expect("write_mem_files");
+
+        let mut names: Vec<String> = fs::read_dir(dir.path())
+            .expect("output dir")
+            .map(|entry| {
+                entry
+                    .expect("dir entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            [
+                "parameters.json",
+                "parameters.mem",
+                "parameters_decay.mem",
+                "parameters_weights.mem",
+            ]
+        );
+
+        let thresholds = read_mem_lines(dir.path().join("parameters.mem"));
+        let weights = read_mem_lines(dir.path().join("parameters_weights.mem"));
+        let decay_rates = read_mem_lines(dir.path().join("parameters_decay.mem"));
+
+        assert_uppercase_hex_words(&thresholds);
+        assert_uppercase_hex_words(&weights);
+        assert_uppercase_hex_words(&decay_rates);
+
+        // 1.0 -> 0x0100, 0.75 -> 0x00C0 (letter digit proves uppercase)
+        assert_eq!(thresholds, ["0100", "00C0"]);
+        // Flattened row-major: 0.5, 2.0, 0.25, 1.5
+        assert_eq!(weights, ["0080", "0200", "0040", "0180"]);
+        assert_eq!(decay_rates, ["0080", "00C0"]);
+    }
+
+    #[test]
+    fn test_mem_files_round_trip_to_parameter_export() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let exporter = mem_writer_fixture();
+
+        MemFileWriter::write_mem_files(&exporter, dir.path()).expect("write_mem_files");
+
+        let expected = ParameterExport::export(&exporter);
+        let thresholds = parse_mem_words(&read_mem_lines(dir.path().join("parameters.mem")));
+        let weights = parse_mem_words(&read_mem_lines(
+            dir.path().join("parameters_weights.mem"),
+        ));
+        let decay_rates = parse_mem_words(&read_mem_lines(dir.path().join("parameters_decay.mem")));
+
+        assert_eq!(thresholds, expected.thresholds);
+        assert_eq!(weights, expected.weights);
+        assert_eq!(decay_rates, expected.decay_rates);
+
+        let decoded: Vec<f32> = thresholds.iter().copied().map(q88_to_f32).collect();
+        for (got, want) in decoded.iter().zip([1.0_f32, 0.75]) {
+            assert!(
+                (got - want).abs() < 1e-6,
+                "Q8.8 round-trip drifted: got {got}, want {want}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_metadata_json_round_trips_to_fpga_parameters() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let exporter = mem_writer_fixture();
+
+        MemFileWriter::write_mem_files(&exporter, dir.path()).expect("write_mem_files");
+
+        let json = fs::read_to_string(dir.path().join("parameters.json")).expect("parameters.json");
+        let round_tripped: FpgaParameters =
+            serde_json::from_str(&json).expect("parameters.json should deserialize");
+
+        let expected = ParameterExport::export(&exporter);
+        assert_eq!(round_tripped.thresholds, expected.thresholds);
+        assert_eq!(round_tripped.weights, expected.weights);
+        assert_eq!(round_tripped.decay_rates, expected.decay_rates);
+
+        assert_eq!(round_tripped.metadata.version, EXPORT_FORMAT_VERSION);
+        assert_eq!(round_tripped.metadata.num_neurons, 2);
+        assert_eq!(round_tripped.metadata.num_channels, 2);
+        assert!(!round_tripped.metadata.timestamp.is_empty());
+        assert!((round_tripped.metadata.target_latency_us - 35.0).abs() < 1e-6);
+        // (2 thresholds + 4 weights + 2 decay) * 2 bytes = 16 bytes
+        assert!((round_tripped.metadata.memory_usage_kb - 16.0 / 1024.0).abs() < 1e-6);
+    }
 }


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #22. Linear: [RM-300](https://linear.app/rpd-34/issue/RM-300).

## What changed

Adds tempfile-based tests for `MemFileWriter::write_mem_files` / `ParameterExport` `.mem` + metadata JSON output. Test-only; uses the existing `tempfile` dev-dependency.

| Test | Covers |
|---|---|
| `test_write_mem_files_via_trait_emits_expected_files` | Exact filenames (`parameters.mem`, `parameters_weights.mem`, `parameters_decay.mem`, `parameters.json`); uppercase 4-digit hex (`XXXX`); Q8.8 fixture words including `0.75 → 00C0` |
| `test_mem_files_round_trip_to_parameter_export` | Re-parse hex lines and compare to `ParameterExport::export` |
| `test_metadata_json_round_trips_to_fpga_parameters` | `parameters.json` deserializes to `FpgaParameters` with matching vectors and metadata |

Writes go through the **trait path** (`MemFileWriter::write_mem_files`), not the inherent wrapper.

## Non-goals

FPGA programming and UART are untouched.

## Validation

| Command | Result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo clippy --all-targets -- -D warnings` | pass |
| `cargo test` | pass — 7 unit tests (4 existing + 3 new) + 1 doctest |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6605d482-bc8d-4d62-bfcc-28151c3e6d9b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6605d482-bc8d-4d62-bfcc-28151c3e6d9b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #22 (RM-300) by adding tempfile-based tests for `MemFileWriter`'s `.mem` and metadata JSON output, covering exact filenames, uppercase hex words, Q8.8 values, and round-trips back to `ParameterExport` and `FpgaParameters`. Test-only; no changes to FPGA programming or UART paths.

- Tests write through the trait path `MemFileWriter::write_mem_files`, not the inherent wrapper.

<sup>Written for commit 18499a706ded89d1e9394946655cb857711f2c1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/silicon-bridge/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Verify FPGA parameter file exports and round trips

### What Changed
- Added coverage confirming `.mem` exports create the expected files with four-character uppercase hexadecimal values
- Verified exported thresholds, weights, and decay rates can be read back without changing their values
- Verified metadata JSON restores FPGA parameters and export details, including dimensions, latency, and memory usage

### Impact
`✅ Fewer undetected FPGA export format regressions`
`✅ Reliable parameter round trips`
`✅ Validated export metadata`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
