### PR TITLE
docs(fpga-bridge): dual Q8.8 convention (unsigned export vs signed UART)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `encode_q88_unsigned` — free-function unsigned Q8.8 encoder shared by
+  `FixedPointEncode::encode_q88`, `.mem` export, and `format_q88_hex` (#23).
+- `encode_q88_signed`, `q88_signed_to_f32`, `STIMULUS_Q88_MIN`, and
+  `STIMULUS_Q88_MAX` — signed Q8.8 host-stimulus helpers used by the UART TX/RX
+  path (#23).
+
 ### Changed
 
 - License switched from GPL-3.0-or-later to dual MIT/Apache-2.0 (#6).
+- Documented the two coexisting Q8.8 conventions (unsigned `u16` export vs
+  signed `i16` UART stimuli) with a side-by-side table in the crate, module, and
+  README docs, plus tests covering both clamp boundaries (#23).

--- a/README.md
+++ b/README.md
@@ -64,14 +64,31 @@ let (_potentials, spikes) = bridge.process_stimuli(&stimuli)?;
 
 ## Q8.8 Fixed-Point Format
 
-```
-Q8.8:  value = raw_u16 / 256.0
-       raw   = clamp(value × 256, 0, 65535) truncated to u16
-Range: [0, 255.996]  (unsigned)
-       [-128, 127.996]  (signed, two's complement)
-```
+Q8.8 always means “value × 256 packed into a 16-bit word”, but this crate
+carries **two signedness conventions** that are not interchangeable:
+parameters baked into the bitstream are unsigned; host stimuli sent over UART
+are signed.
 
-Directly loadable by silicon-hdl `WeightRam.sv` and `NeuronParamRam.sv`
+| Aspect | Parameter export (`.mem`) | Host stimuli (UART TX/RX) |
+|---|---|---|
+| Encode with | `FixedPointEncode::encode_q88` / `encode_q88_unsigned` | `encode_q88_signed` |
+| Decode with | `q88_to_f32` | `q88_signed_to_f32` |
+| Raw type | `u16` (unsigned) | `i16` (two's complement) |
+| Width | 16 bits — 8 integer + 8 fractional | 16 bits — 8 integer + 8 fractional |
+| Scaling | `raw = value × 256`, truncated toward zero | `raw = value × 256`, truncated toward zero |
+| Encoder input clamp | `[0.0, 255.99609375]` (scaled clamp `0..=65535`) | `[-127.99, 127.99]` |
+| Encoder raw output | `0..=65535` | `-32765..=32765` (saturates inside the `i16` limits) |
+| Decoder accepts | any `u16`: `0..=65535` → `0.0..=255.99609375` | any `i16`: `-32768..=32767` → `-128.0..=127.99609375` |
+| Serialized as | ASCII hex, one `{:04X}` word per line (`$readmemh`) | raw binary, big-endian (MSB first) |
+| Use it for | weights, thresholds, decay rates | host stimuli, RX membrane potentials |
+
+The export path **cannot represent negative values** — anything below `0.0`
+clamps to raw `0`. Both encoders truncate toward zero and map `NaN` to raw `0`.
+The signed decoder is wider than its encoder: the FPGA may send any `i16`, so
+`0x8000` decodes to `-128.0` even though TX saturates at `±32765`.
+
+Exported `.mem` files are directly loadable by silicon-hdl `WeightRam.sv` and
+`NeuronParamRam.sv`
 ([Limen-Neural/silicon-hdl](https://github.com/Limen-Neural/silicon-hdl)).
 
 ## Repo boundaries

--- a/src/fpga_bridge.rs
+++ b/src/fpga_bridge.rs
@@ -5,6 +5,22 @@
 //! and read back spike states using the SiliconBridge v3.0 protocol.
 //!
 //! Extracted from Eagle-Lander's Ship of Theseus neuromorphic core.
+//!
+//! ## Q8.8 convention used here: signed
+//!
+//! Host stimuli and membrane potentials on the wire are **signed** Q8.8
+//! (`i16`, two's complement, big-endian). Parameter export (`.mem`) uses
+//! **unsigned** `u16` instead. Encoding a stimulus with the export encoder
+//! turns every negative (inhibitory) input into `0`.
+//!
+//! | Aspect | This module (UART TX/RX) | `fpga_export` (`.mem`) |
+//! |---|---|---|
+//! | Encode with | [`crate::encode_q88_signed`] | [`crate::encode_q88_unsigned`] |
+//! | Decode with | [`crate::q88_signed_to_f32`] | [`crate::q88_to_f32`] |
+//! | Raw type | `i16` (two's complement) | `u16` (unsigned) |
+//! | Encoder input clamp | [`crate::STIMULUS_Q88_MIN`]`..=`[`crate::STIMULUS_Q88_MAX`] | `0.0..=255.99609375` |
+//! | Byte order | raw binary, big-endian (MSB first) | ASCII hex, one `{:04X}` word per line |
+//! | Use it for | host stimuli, RX membrane potentials | weights, thresholds, decay rates |
 
 use serialport::{SerialPort, SerialPortInfo};
 use std::io::{Read, Write};
@@ -40,8 +56,12 @@ impl FpgaBridge {
     /// Send neural stimuli to FPGA and read back spike states.
     ///
     /// Protocol (16-neuron SiliconBridge v3.0):
-    ///   TX: 0xAA + 32 bytes (16 × Q8.8 stimuli)
-    ///   RX: 32 bytes (16 × Q8.8 potentials) + 2 bytes (spike flags) + 2 bytes (switches)
+    ///   TX: 0xAA + 32 bytes (16 × signed Q8.8 stimuli, big-endian)
+    ///   RX: 32 bytes (16 × signed Q8.8 potentials) + 2 bytes (spike flags) + 2 bytes (switches)
+    ///
+    /// Stimuli are encoded with [`crate::encode_q88_signed`] (`i16`) — **not**
+    /// the unsigned `.mem` export encoder. RX potentials use
+    /// [`crate::q88_signed_to_f32`].
     ///
     /// Input is accepted as a dynamic slice; if fewer than 16 values are provided,
     /// remaining channels are zero-padded. If more are provided, only the first 16 are sent.
@@ -53,11 +73,11 @@ impl FpgaBridge {
             return Err("FPGA bridge not active".into());
         }
 
-        // Convert stimuli to Q8.8 format (16-bit fixed point)
+        // ENCODE SITE (signed Q8.8) — UART TX. Not the unsigned u16 export path.
         let mut tx_data = vec![0xAAu8]; // Sync byte
         for i in 0..16 {
             let s = stimuli.get(i).copied().unwrap_or(0.0);
-            let q8_8 = (s.clamp(-127.99, 127.99) * 256.0) as i16;
+            let q8_8 = crate::encode_q88_signed(s);
             tx_data.extend_from_slice(&q8_8.to_be_bytes());
         }
 
@@ -69,11 +89,11 @@ impl FpgaBridge {
         let mut rx_data = vec![0u8; 36];
         self.port.read_exact(&mut rx_data)?;
 
-        // Parse potentials (Q8.8 back to f32)
+        // DECODE SITE (signed Q8.8, big-endian) — membrane potentials can be negative.
         let mut potentials = Vec::with_capacity(16);
         for i in 0..16 {
             let raw = i16::from_be_bytes([rx_data[i * 2], rx_data[i * 2 + 1]]);
-            potentials.push(raw as f32 / 256.0);
+            potentials.push(crate::q88_signed_to_f32(raw));
         }
 
         // Parse spike flags (16-bit, 1 per neuron)

--- a/src/fpga_export.rs
+++ b/src/fpga_export.rs
@@ -325,7 +325,7 @@ pub const STIMULUS_Q88_MAX: f32 = 127.99;
 /// Single source of truth for the export-path encoding used by
 /// [`FixedPointEncode::encode_q88`], `.mem` files, and [`format_q88_hex`]:
 /// `raw = value × 256`, truncated toward zero, scaled result clamped to
-/// `0..=65535`.
+/// `0..=65535`. `NaN` encodes as `0`.
 ///
 /// Host stimuli over UART must **not** use this function — they use
 /// [`encode_q88_signed`].
@@ -341,6 +341,10 @@ pub const STIMULUS_Q88_MAX: f32 = 127.99;
 pub fn encode_q88_unsigned(value: f32) -> u16 {
     // ENCODE SITE (unsigned Q8.8) — clamp on the *scaled* value, so the
     // representable input range is 0.0..=255.99609375 (65535 / 256).
+    // `f32::clamp` propagates NaN, so map it to 0 before the cast.
+    if value.is_nan() {
+        return 0;
+    }
     let scaled = value * 256.0;
     scaled.clamp(0.0, 65535.0) as u16
 }
@@ -365,6 +369,10 @@ pub fn encode_q88_signed(value: f32) -> i16 {
     // ENCODE SITE (signed Q8.8) — UART / host-stimulus path.
     // Clamp happens on the *unscaled* value so saturation lands on raw
     // ±32765 (±127.99 × 256, truncated) rather than the i16 limits.
+    // `f32::clamp` propagates NaN, so map it to 0 before the i16 cast.
+    if value.is_nan() {
+        return 0;
+    }
     (value.clamp(STIMULUS_Q88_MIN, STIMULUS_Q88_MAX) * 256.0) as i16
 }
 

--- a/src/fpga_export.rs
+++ b/src/fpga_export.rs
@@ -13,6 +13,22 @@
 //! - [`FixedPointEncode`] — `f32` → Q8.8 `u16`
 //! - [`ParameterExport`] — produce [`FpgaParameters`]
 //! - [`MemFileWriter`] — write `.mem` + metadata JSON
+//!
+//! ## Q8.8 convention used here: unsigned
+//!
+//! This module encodes **unsigned** Q8.8 (`u16`). Host stimuli on the UART path
+//! use a **signed** `i16` convention ([`encode_q88_signed`]). The two are not
+//! interchangeable — see the crate-root “Q8.8 conventions” table.
+//!
+//! | Aspect | This module (`.mem` export) |
+//! |---|---|
+//! | Raw type | `u16` (unsigned — negatives are **not** representable) |
+//! | Width | 16 bits — 8 integer + 8 fractional |
+//! | Scaling | `raw = value × 256`, truncated toward zero |
+//! | Encoder input clamp | `[0.0, 255.99609375]` (scaled clamp `0..=65535`) |
+//! | Encoder raw output | `0..=65535` |
+//! | Serialized as | ASCII hex, one `{:04X}` word per line for `$readmemh` |
+//! | Use it for | weights, thresholds, decay rates |
 
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -29,8 +45,16 @@ pub const EXPORT_FORMAT_VERSION: &str = "Spikenaut-v2";
 ///
 /// Q8.8 maps `value × 256` into a 16-bit word. Values outside the representable
 /// range are clamped.
+///
+/// This is the **unsigned** convention (`0.0..=255.99609375`, raw `0..=65535`)
+/// used for `.mem` parameter export. Host stimuli sent over UART use the signed
+/// `i16` convention ([`encode_q88_signed`]) — see the crate-root
+/// “Q8.8 conventions” table.
 pub trait FixedPointEncode {
-    /// Convert one `f32` to Q8.8 fixed-point.
+    /// Convert one `f32` to unsigned Q8.8 fixed-point.
+    ///
+    /// Negative inputs clamp to `0`; inputs above `255.99609375` clamp to
+    /// `65535`; `NaN` encodes as `0`.
     fn encode_q88(&self, value: f32) -> u16;
 }
 
@@ -199,10 +223,10 @@ impl FpgaParameterExporter {
 
 impl FixedPointEncode for FpgaParameterExporter {
     fn encode_q88(&self, value: f32) -> u16 {
-        // Q8.8: 8 integer bits, 8 fractional bits
-        // Range: 0.0 to 255.996 (clamped into u16)
-        let scaled = value * 256.0;
-        scaled.clamp(0.0, 65535.0) as u16
+        // ENCODE SITE (unsigned Q8.8) — `.mem` / synthesis path.
+        // Negatives are not representable and clamp to 0. Signed host stimuli
+        // use encode_q88_signed (i16) instead.
+        encode_q88_unsigned(value)
     }
 }
 
@@ -286,14 +310,82 @@ impl Default for FpgaParameterExporter {
     }
 }
 
-/// Helper function to format Q8.8 value as hex string
-pub fn format_q88_hex(value: f32) -> String {
-    let exporter = FpgaParameterExporter::new();
-    let q88_value = exporter.encode_q88(value);
-    format!("{:04X}", q88_value)
+/// Lower clamp bound for host stimuli on the signed Q8.8 UART path.
+///
+/// Values below this saturate to raw `-32765` (`i16`).
+pub const STIMULUS_Q88_MIN: f32 = -127.99;
+
+/// Upper clamp bound for host stimuli on the signed Q8.8 UART path.
+///
+/// Values above this saturate to raw `32765` (`i16`).
+pub const STIMULUS_Q88_MAX: f32 = 127.99;
+
+/// Encode an `f32` as **unsigned** Q8.8 (`u16`) without needing an exporter.
+///
+/// Single source of truth for the export-path encoding used by
+/// [`FixedPointEncode::encode_q88`], `.mem` files, and [`format_q88_hex`]:
+/// `raw = value × 256`, truncated toward zero, scaled result clamped to
+/// `0..=65535`.
+///
+/// Host stimuli over UART must **not** use this function — they use
+/// [`encode_q88_signed`].
+///
+/// ```rust
+/// use silicon_bridge::{encode_q88_unsigned, q88_to_f32};
+///
+/// assert_eq!(encode_q88_unsigned(1.0), 256);
+/// assert_eq!(encode_q88_unsigned(-1.0), 0); // no negatives on the export path
+/// assert_eq!(encode_q88_unsigned(1000.0), 65535); // saturates
+/// assert_eq!(q88_to_f32(encode_q88_unsigned(0.5)), 0.5);
+/// ```
+pub fn encode_q88_unsigned(value: f32) -> u16 {
+    // ENCODE SITE (unsigned Q8.8) — clamp on the *scaled* value, so the
+    // representable input range is 0.0..=255.99609375 (65535 / 256).
+    let scaled = value * 256.0;
+    scaled.clamp(0.0, 65535.0) as u16
 }
 
-/// Helper function to convert Q8.8 back to f32
+/// Encode a host stimulus as **signed** Q8.8 (`i16`, two's complement).
+///
+/// `raw = value × 256`, truncated toward zero, with the *unscaled* input
+/// clamped to [`STIMULUS_Q88_MIN`]`..=`[`STIMULUS_Q88_MAX`]. `NaN` encodes as
+/// `0`. The UART wire format is big-endian (`to_be_bytes()`).
+///
+/// This is not interchangeable with [`encode_q88_unsigned`].
+///
+/// ```rust
+/// use silicon_bridge::{encode_q88_signed, q88_signed_to_f32};
+///
+/// assert_eq!(encode_q88_signed(1.0), 256);
+/// assert_eq!(encode_q88_signed(-1.0), -256); // negatives survive here
+/// assert_eq!(encode_q88_signed(-1.0).to_be_bytes(), [0xFF, 0x00]);
+/// assert_eq!(q88_signed_to_f32(encode_q88_signed(-0.5)), -0.5);
+/// ```
+pub fn encode_q88_signed(value: f32) -> i16 {
+    // ENCODE SITE (signed Q8.8) — UART / host-stimulus path.
+    // Clamp happens on the *unscaled* value so saturation lands on raw
+    // ±32765 (±127.99 × 256, truncated) rather than the i16 limits.
+    (value.clamp(STIMULUS_Q88_MIN, STIMULUS_Q88_MAX) * 256.0) as i16
+}
+
+/// Decode a **signed** Q8.8 (`i16`) wire word back to `f32`.
+///
+/// Counterpart of [`encode_q88_signed`], but wider: every `i16` the FPGA can
+/// send is valid (`-32768..=32767` → `-128.0..=127.99609375`).
+pub fn q88_signed_to_f32(raw: i16) -> f32 {
+    raw as f32 / 256.0
+}
+
+/// Helper function to format unsigned Q8.8 value as hex string
+pub fn format_q88_hex(value: f32) -> String {
+    format!("{:04X}", encode_q88_unsigned(value))
+}
+
+/// Convert **unsigned** Q8.8 back to `f32`.
+///
+/// Counterpart of [`encode_q88_unsigned`]. For the signed UART path use
+/// [`q88_signed_to_f32`] — decoding a signed raw word with this function
+/// reads negatives as large positives.
 pub fn q88_to_f32(q88_value: u16) -> f32 {
     q88_value as f32 / 256.0
 }
@@ -375,5 +467,165 @@ mod tests {
         assert_eq!(params.thresholds, vec![256]);
         assert_eq!(params.weights, vec![128]);
         assert_eq!(params.decay_rates, vec![230]);
+    }
+}
+
+#[cfg(test)]
+mod q88_convention_tests {
+    use super::*;
+
+    const MAX_UNSIGNED_INPUT: f32 = 65535.0 / 256.0; // 255.99609375
+
+    #[test]
+    fn unsigned_encode_scales_by_256() {
+        assert_eq!(encode_q88_unsigned(0.0), 0);
+        assert_eq!(encode_q88_unsigned(1.0), 256);
+        assert_eq!(encode_q88_unsigned(0.5), 128);
+        assert_eq!(encode_q88_unsigned(1.0 / 256.0), 1);
+        assert_eq!(encode_q88_unsigned(255.0), 65280);
+    }
+
+    #[test]
+    fn unsigned_encode_truncates_toward_zero() {
+        assert_eq!(encode_q88_unsigned(0.999), 255);
+        assert_eq!(encode_q88_unsigned(1.9999), 511);
+    }
+
+    #[test]
+    fn unsigned_encode_clamps_at_both_ends() {
+        assert_eq!(encode_q88_unsigned(MAX_UNSIGNED_INPUT), 65535);
+        assert_eq!(encode_q88_unsigned(256.0), 65535);
+        assert_eq!(encode_q88_unsigned(1.0e6), 65535);
+        assert_eq!(encode_q88_unsigned(f32::MAX), 65535);
+        assert_eq!(encode_q88_unsigned(f32::INFINITY), 65535);
+
+        assert_eq!(encode_q88_unsigned(0.0), 0);
+        assert_eq!(encode_q88_unsigned(-1.0 / 256.0), 0);
+        assert_eq!(encode_q88_unsigned(-1.0), 0);
+        assert_eq!(encode_q88_unsigned(-127.99), 0);
+        assert_eq!(encode_q88_unsigned(f32::MIN), 0);
+        assert_eq!(encode_q88_unsigned(f32::NEG_INFINITY), 0);
+    }
+
+    #[test]
+    fn unsigned_encode_maps_nan_to_zero() {
+        assert_eq!(encode_q88_unsigned(f32::NAN), 0);
+    }
+
+    #[test]
+    fn unsigned_encode_round_trips_through_q88_to_f32() {
+        for value in [0.0_f32, 0.00390625, 0.5, 1.0, 12.25, MAX_UNSIGNED_INPUT] {
+            let raw = encode_q88_unsigned(value);
+            assert_eq!(q88_to_f32(raw), value, "round trip failed for {value}");
+        }
+    }
+
+    #[test]
+    fn trait_and_inherent_encoders_match_the_free_function() {
+        let exporter = FpgaParameterExporter::new();
+        for value in [-5.0_f32, 0.0, 0.3, 1.0, 255.0, 300.0] {
+            let expected = encode_q88_unsigned(value);
+            assert_eq!(FixedPointEncode::encode_q88(&exporter, value), expected);
+            assert_eq!(exporter.to_q88(value), expected);
+        }
+    }
+
+    #[test]
+    fn mem_words_are_four_hex_digits_uppercase() {
+        assert_eq!(format_q88_hex(0.0), "0000");
+        assert_eq!(format_q88_hex(1.0), "0100");
+        assert_eq!(format_q88_hex(MAX_UNSIGNED_INPUT), "FFFF");
+        assert_eq!(format_q88_hex(-1.0), "0000");
+    }
+
+    #[test]
+    fn signed_encode_scales_by_256_in_both_directions() {
+        assert_eq!(encode_q88_signed(0.0), 0);
+        assert_eq!(encode_q88_signed(1.0), 256);
+        assert_eq!(encode_q88_signed(-1.0), -256);
+        assert_eq!(encode_q88_signed(0.5), 128);
+        assert_eq!(encode_q88_signed(-0.5), -128);
+        assert_eq!(encode_q88_signed(1.0 / 256.0), 1);
+        assert_eq!(encode_q88_signed(-1.0 / 256.0), -1);
+    }
+
+    #[test]
+    fn signed_encode_truncates_toward_zero() {
+        assert_eq!(encode_q88_signed(0.999), 255);
+        assert_eq!(encode_q88_signed(-0.999), -255);
+    }
+
+    #[test]
+    fn signed_encode_clamps_at_both_ends() {
+        assert_eq!(encode_q88_signed(STIMULUS_Q88_MAX), 32765);
+        assert_eq!(encode_q88_signed(STIMULUS_Q88_MIN), -32765);
+        assert_eq!(encode_q88_signed(128.0), 32765);
+        assert_eq!(encode_q88_signed(-128.0), -32765);
+        assert_eq!(encode_q88_signed(1.0e6), 32765);
+        assert_eq!(encode_q88_signed(-1.0e6), -32765);
+        assert_eq!(encode_q88_signed(f32::MAX), 32765);
+        assert_eq!(encode_q88_signed(f32::MIN), -32765);
+        assert_eq!(encode_q88_signed(f32::INFINITY), 32765);
+        assert_eq!(encode_q88_signed(f32::NEG_INFINITY), -32765);
+    }
+
+    #[test]
+    fn signed_encode_maps_nan_to_zero() {
+        assert_eq!(encode_q88_signed(f32::NAN), 0);
+    }
+
+    #[test]
+    fn signed_wire_words_are_big_endian() {
+        assert_eq!(encode_q88_signed(1.0).to_be_bytes(), [0x01, 0x00]);
+        assert_eq!(encode_q88_signed(-1.0).to_be_bytes(), [0xFF, 0x00]);
+        assert_eq!(encode_q88_signed(-0.5).to_be_bytes(), [0xFF, 0x80]);
+        assert_eq!(
+            encode_q88_signed(STIMULUS_Q88_MAX).to_be_bytes(),
+            [0x7F, 0xFD]
+        );
+    }
+
+    #[test]
+    fn signed_encode_round_trips_through_q88_signed_to_f32() {
+        for value in [-127.0_f32, -12.25, -1.0, -0.00390625, 0.0, 0.5, 64.75] {
+            let raw = encode_q88_signed(value);
+            assert_eq!(
+                q88_signed_to_f32(raw),
+                value,
+                "round trip failed for {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn signed_decoder_covers_the_full_i16_wire_range() {
+        assert_eq!(q88_signed_to_f32(i16::MIN), -128.0);
+        assert_eq!(q88_signed_to_f32(i16::MAX), 32767.0 / 256.0);
+        assert!(encode_q88_signed(-128.0) > i16::MIN);
+        assert!(encode_q88_signed(f32::MAX) < i16::MAX);
+    }
+
+    #[test]
+    fn signed_and_unsigned_agree_only_on_the_shared_range() {
+        for value in [0.0_f32, 0.5, 1.0, 64.25, 127.0] {
+            assert_eq!(
+                i32::from(encode_q88_signed(value)),
+                i32::from(encode_q88_unsigned(value)),
+                "conventions should agree for {value}"
+            );
+        }
+
+        assert_eq!(encode_q88_signed(200.0), 32765);
+        assert_eq!(encode_q88_unsigned(200.0), 51200);
+    }
+
+    #[test]
+    fn using_the_wrong_convention_corrupts_negative_values() {
+        assert_eq!(encode_q88_signed(-1.0), -256);
+        assert_eq!(encode_q88_unsigned(-1.0), 0);
+
+        let wire = encode_q88_signed(-1.0);
+        assert_eq!(q88_signed_to_f32(wire), -1.0);
+        assert_eq!(q88_to_f32(wire as u16), 255.0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,33 @@
 //!
 //! Licensed under either of MIT or Apache-2.0 at your option.
 //!
+//! ## Q8.8 conventions
+//!
+//! Q8.8 always means “value × 256 packed into a 16-bit word”, but this crate
+//! carries **two signedness conventions** that are not interchangeable.
+//! Parameters baked into the bitstream are unsigned; host stimuli pushed over
+//! UART are signed two's complement.
+//!
+//! | Aspect | Parameter export (`.mem`) | Host stimuli (UART TX/RX) |
+//! |---|---|---|
+//! | Encode with | [`FixedPointEncode::encode_q88`] / [`encode_q88_unsigned`] | [`encode_q88_signed`] |
+//! | Decode with | [`q88_to_f32`] | [`q88_signed_to_f32`] |
+//! | Raw type | `u16` (unsigned) | `i16` (two's complement) |
+//! | Width | 16 bits — 8 integer + 8 fractional | 16 bits — 8 integer + 8 fractional |
+//! | Scaling | `raw = value × 256`, truncated toward zero | `raw = value × 256`, truncated toward zero |
+//! | Encoder input clamp | `[0.0, 255.99609375]` (scaled clamp `0..=65535`) | [`STIMULUS_Q88_MIN`]`..=`[`STIMULUS_Q88_MAX`] (`-127.99..=127.99`) |
+//! | Encoder raw output | `0..=65535` | `-32765..=32765` (saturates inside the `i16` limits) |
+//! | Decoder accepts | any `u16`: `0..=65535` → `0.0..=255.99609375` | any `i16`: `-32768..=32767` → `-128.0..=127.99609375` |
+//! | Serialized as | ASCII hex, one `{:04X}` word per line (`$readmemh`) | raw binary, big-endian (MSB first) |
+//! | Consumed by | silicon-hdl `WeightRam` / `NeuronParamRam` | SiliconBridge v3.0 UART frame |
+//! | Use it for | weights, thresholds, decay rates | host stimuli, RX membrane potentials |
+//!
+//! The export path **cannot represent negative values**; anything below `0.0`
+//! clamps to raw `0`. The signed encoder saturates at `±32765`; the signed
+//! decoder is wider so an FPGA word of `0x8000` decodes to `-128.0`. Both
+//! encoders truncate toward zero and map `NaN` to raw `0`. No silicon-hdl
+//! wire protocol change is implied by documenting this split.
+//!
 //! ## Provenance
 //!
 //! Extracted from Eagle-Lander, the author's own private neuromorphic GPU supervisor
@@ -48,7 +75,8 @@ mod fpga_bridge;
 // Re-export public API
 pub use fpga_export::{
     EXPORT_FORMAT_VERSION, FixedPointEncode, FpgaMetadata, FpgaParameterExporter, FpgaParameters,
-    MemFileWriter, ParameterExport, format_q88_hex, q88_to_f32,
+    MemFileWriter, ParameterExport, STIMULUS_Q88_MAX, STIMULUS_Q88_MIN, encode_q88_signed,
+    encode_q88_unsigned, format_q88_hex, q88_signed_to_f32, q88_to_f32,
 };
 
 pub use fpga_metrics::FpgaMetrics;


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #23. Linear: [RM-298](https://linear.app/rpd-34/issue/RM-298).

## Problem

Two Q8.8 conventions coexist, and the public API did not make the split obvious:

- **Export** (`FixedPointEncode` / `.mem`): unsigned `u16`, `value × 256`, clamp `0..=65535`
- **UART TX/RX** (`FpgaBridge::process_stimuli`): signed `i16`, clamp `[-127.99, 127.99]`, big-endian

Mixing them silently corrupts data (negative stimuli become `0`; signed wire words decode as large positives).

## What changed

- Side-by-side conventions table in crate rustdoc, `fpga_export`, `fpga_bridge`, and README
- Encode-site comments at unsigned export and signed UART encode/decode
- Additive, non-breaking helpers: `encode_q88_unsigned`, `encode_q88_signed`, `q88_signed_to_f32`, `STIMULUS_Q88_MIN` / `STIMULUS_Q88_MAX`
- Tests for scaling, truncation, both clamp ends, NaN, endianness, and wrong-convention corruption
- Signed helpers live in `fpga_export` so default `cargo test` covers both paths without `libudev`

No silicon-hdl protocol change: clamp values and encoded results stay bit-identical.

## Non-goals

NIR; changing the SiliconBridge v3.0 wire format.

## Validation

| Command | Result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo clippy --all-targets -- -D warnings` | pass |
| `cargo test` | pass — 20 unit tests + 3 doctests |
| `cargo check --features uart` | pass (with `libudev-dev`) |
| `cargo clippy --all-targets --features uart -- -D warnings` | pass |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6605d482-bc8d-4d62-bfcc-28151c3e6d9b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6605d482-bc8d-4d62-bfcc-28151c3e6d9b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the silent data corruption from mixing Q8.8 conventions in `silicon_bridge` (RM-298): `.mem` parameter export is unsigned `u16`, while UART host stimuli are signed `i16`. The old docs didn't make the split obvious, so negative stimuli encoded to `0` and signed wire words decoded as large positives. Both encoders now map `NaN` to `0` deterministically instead of relying on a platform-dependent clamp-and-cast result.

**Highlights**
- Adds shared helpers `encode_q88_unsigned`, `encode_q88_signed`, `q88_signed_to_f32`, and `STIMULUS_Q88_MIN` / `STIMULUS_Q88_MAX` clamp bounds.
- Documents both conventions with side-by-side tables in crate docs, `fpga_export`, `fpga_bridge`, and README, plus encode-site comments.
- Tests cover scaling, truncation, both clamp ends, NaN, endianness, and wrong-convention corruption.
- Keeps the wire protocol unchanged: clamp values and encoded results stay bit-identical.

<sup>Written for commit f448d6ae94b5a0375ce829fbac6a3c26909ef2c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/silicon-bridge/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Clarify and enforce separate Q8.8 formats for FPGA exports and UART stimuli

### What Changed
- UART stimuli and returned membrane potentials now use signed Q8.8 values, preserving negative inputs and outputs over the wire.
- Parameter `.mem` exports continue using unsigned Q8.8 values, with negative inputs clamped to zero.
- Added public helpers for signed and unsigned encoding and decoding, including documented stimulus limits.
- Added side-by-side guidance in the crate documentation, module docs, README, and changelog to prevent mixing the two formats.
- Added coverage for scaling, truncation, clamping, NaN handling, byte order, round trips, and wrong-format decoding.

### Impact
`✅ Negative UART stimuli preserved`
`✅ Correctly decoded negative membrane potentials`
`✅ Fewer Q8.8 format mix-ups`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
