### PR TITLE
docs: fix README accuracy (sync UART, WNS-only metrics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@
 
 The Rust-side bridge between trained SNN parameters and FPGA hardware. Exports
 weights and thresholds as Q8.8 fixed-point `.mem` files for Vivado/Quartus
-`$readmemh`, and provides an async UART bridge for sending stimuli and reading
-back spike states at runtime.
+`$readmemh`, and provides an optional **synchronous** UART bridge — built on the
+blocking `serialport` crate and gated behind the `uart` feature — for sending
+stimuli and reading back spike states at runtime.
 
 ## Features
 
@@ -26,8 +27,11 @@ back spike states at runtime.
   - `MemFileWriter` — write `$readmemh` `.mem` files
 - `FpgaParameterExporter` — default implementation of those traits
 - `format_q88_hex` / `q88_to_f32` — Q8.8 helpers
-- `FpgaBridge` — UART protocol for host–FPGA spike exchange (`uart` feature)
-- `FpgaMetrics` — Vivado timing report parser (**WNS** for CI/CD gating; LUT field reserved / not parsed yet)
+- `FpgaBridge` — blocking UART host protocol for host–FPGA spike exchange,
+  backed by `serialport` (`uart` feature); no async runtime is involved
+- `FpgaMetrics` — Vivado timing report parser: **WNS only** for CI/CD gating.
+  TNS is not parsed, and `lut_utilization` is a reserved field that the loaders
+  leave at `0.0` (both tracked by #21)
 
 ## Installation
 
@@ -52,7 +56,11 @@ let params = ParameterExport::export(&exporter);
 // → ready for silicon-hdl WeightRam / NeuronParamRam via Vivado $readmemh
 ```
 
-### UART Spike Readback
+### UART Spike Readback (requires the `uart` feature)
+
+```toml
+silicon-bridge = { version = "0.1", features = ["uart"] }
+```
 
 ```rust
 use silicon_bridge::FpgaBridge;
@@ -61,6 +69,10 @@ let mut bridge = FpgaBridge::new()?;
 let stimuli = vec![0.1; 16];
 let (_potentials, spikes) = bridge.process_stimuli(&stimuli)?;
 ```
+
+`FpgaBridge` is synchronous. `process_stimuli` writes the request frame and then
+blocks until the FPGA replies or the port's 100 ms read timeout elapses; nothing
+in this API returns a `Future`, and no async executor is required.
 
 ## Q8.8 Fixed-Point Format
 
@@ -73,6 +85,31 @@ Range: [0, 255.996]  (unsigned)
 
 Directly loadable by silicon-hdl `WeightRam.sv` and `NeuronParamRam.sv`
 ([Limen-Neural/silicon-hdl](https://github.com/Limen-Neural/silicon-hdl)).
+
+## Vivado Timing Metrics
+
+`FpgaMetrics` parses **WNS** (worst negative slack, in nanoseconds) out of a
+Vivado timing summary report so CI can gate on a timing violation. This matches
+`src/fpga_metrics.rs`: `parse_from_report` / `load_from_path` fill `wns_ns`
+only.
+
+```rust
+use silicon_bridge::FpgaMetrics;
+
+// Fail closed: a missing or unparseable report must not let the gate pass.
+let metrics = FpgaMetrics::load_from_path("Basys3_Top_timing_summary_routed.rpt")
+    .expect("timing report missing or unrecognized");
+assert!(metrics.wns_ns >= 0.0, "timing violation: WNS {} ns", metrics.wns_ns);
+```
+
+WNS is the only value actually parsed. Not implemented yet (tracked by #21):
+
+- **TNS** — there is no `tns_ns` field and no TNS parser
+- **LUT utilization** — `FpgaMetrics::lut_utilization` exists as a field, but
+  `load_from_project` and `load_from_path` hard-code it to `0.0`
+
+Until #21 lands, WNS is the only enforceable gate. See also
+[docs/boundary-matrix.md](docs/boundary-matrix.md).
 
 ## Repo boundaries
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ stimuli and reading back spike states at runtime.
 - `FpgaParameterExporter` — default implementation of those traits
 - `format_q88_hex` / `q88_to_f32` — Q8.8 helpers
 - `FpgaBridge` — blocking UART host protocol for host–FPGA spike exchange,
-  backed by `serialport` (`uart` feature); no async runtime is involved
+  backed by `serialport` (`uart` feature); no async runtime is involved.
+  `FpgaBridge::new()` probes only `/dev/ttyUSB0`, `/dev/ttyUSB1`, and
+  `/dev/ttyUSB2` on Linux — not ttyACM, Windows COM ports, or arbitrary
+  USB paths
 - `FpgaMetrics` — Vivado timing report parser: **WNS only** for CI/CD gating.
   TNS is not parsed, and `lut_utilization` is a reserved field that the loaders
   leave at `0.0` (both tracked by #21)
@@ -70,9 +73,15 @@ let stimuli = vec![0.1; 16];
 let (_potentials, spikes) = bridge.process_stimuli(&stimuli)?;
 ```
 
-`FpgaBridge` is synchronous. `process_stimuli` writes the request frame and then
-blocks until the FPGA replies or the port's 100 ms read timeout elapses; nothing
-in this API returns a `Future`, and no async executor is required.
+`FpgaBridge` is synchronous. `FpgaBridge::new()` opens the first of
+`/dev/ttyUSB0`, `/dev/ttyUSB1`, `/dev/ttyUSB2` that accepts 115200 baud; it
+does not probe ttyACM devices, Windows COM ports, or arbitrary USB paths.
+
+`process_stimuli` writes the request frame and then `read_exact`s the reply.
+The 100 ms value is the `serialport` **per-read** timeout, not a hard
+wall-clock budget for the entire call: a partial reply can retry, so the
+call can exceed 100 ms. Nothing in this API returns a `Future`, and no async
+executor is required.
 
 ## Q8.8 Fixed-Point Format
 
@@ -116,7 +125,11 @@ use silicon_bridge::FpgaMetrics;
 // Fail closed: a missing or unparseable report must not let the gate pass.
 let metrics = FpgaMetrics::load_from_path("Basys3_Top_timing_summary_routed.rpt")
     .expect("timing report missing or unrecognized");
-assert!(metrics.wns_ns >= 0.0, "timing violation: WNS {} ns", metrics.wns_ns);
+assert!(
+    metrics.wns_ns.is_finite() && metrics.wns_ns >= 0.0,
+    "timing violation or non-finite WNS: {} ns",
+    metrics.wns_ns
+);
 ```
 
 WNS is the only value actually parsed. Not implemented yet (tracked by #21):


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #19. Linear: [RM-299](https://linear.app/rpd-34/issue/RM-299).

## What changed

Docs-only README alignment with `src/fpga_bridge.rs` and `src/fpga_metrics.rs`.

- **Async UART claim removed.** `FpgaBridge` is a blocking `serialport` client gated by the `uart` feature. `process_stimuli` does `write_all` + `flush` + `read_exact`. Nothing returns a `Future`.
- **UART ports.** `FpgaBridge::new()` probes only `/dev/ttyUSB0`, `/dev/ttyUSB1`, `/dev/ttyUSB2` on Linux — not ttyACM, Windows COM ports, or arbitrary USB paths.
- **100 ms timeout.** That value is the `serialport` per-read timeout, not a hard wall-clock budget for the entire `process_stimuli` call. Partial reads can retry and exceed 100 ms.
- **Metrics scope.** `FpgaMetrics` parses **WNS only**. There is no TNS parser, and `lut_utilization` stays `0.0` until #21.
- **Fail-closed WNS gate.** Example requires `metrics.wns_ns.is_finite() && metrics.wns_ns >= 0.0` so `inf` cannot pass.
- **`docs/boundary-matrix.md`** remains linked from Repo boundaries and is also referenced from the Vivado Timing Metrics section.

No code behavior changes. Vivado separator-row parser work stays deferred to #21 / a follow-up code PR.

## Validation

| Command | Result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo clippy --all-targets -- -D warnings` | pass |
| `cargo test` | pass — 37 unit tests + 3 doctests |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6605d482-bc8d-4d62-bfcc-28151c3e6d9b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6605d482-bc8d-4d62-bfcc-28151c3e6d9b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the README to match the actual behavior of `FpgaBridge` and `FpgaMetrics`: the bridge is a blocking `serialport` client gated by the `uart` feature, not async, and `FpgaMetrics` parses only WNS — TNS and LUT utilization are deferred to #21. No code changes; docs-only.

**What changed**

- Corrects the UART description to synchronous and adds a feature-flag usage example.
- Documents that `FpgaBridge::new()` probes only `/dev/ttyUSB0`–`/dev/ttyUSB2` on Linux and that the 100 ms value is the per-read `serialport` timeout, not a wall-clock budget.
- Adds a Vivado Timing Metrics section clarifying WNS is the only parsed metric and showing a fail-closed gate that rejects non-finite values.
- Keeps the existing `docs/boundary-matrix.md` link from the Repo boundaries section.

Closes #19, Linear RM-299.

<sup>Written for commit 80033b4b1d074cf90b33c1f450c4fb1c4ac2b6ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/silicon-bridge/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Align README guidance with the actual UART and timing-metrics behavior

### What Changed
- Documents the UART bridge as synchronous, optional, and dependent on the `uart` feature, with no async runtime required
- Clarifies that Linux connection attempts are limited to `/dev/ttyUSB0` through `/dev/ttyUSB2`, and explains the per-read timeout behavior
- Documents that timing reports provide WNS only; TNS is not parsed and LUT utilization remains `0.0`
- Adds a fail-closed WNS validation example that rejects missing, invalid, or non-finite values

### Impact
`✅ Clearer UART setup and connection expectations`
`✅ Fewer incorrect timeout assumptions`
`✅ Safer timing-gate examples`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
