### PR TITLE
ci: repoint project board sync at rmems and fail soft without a token

### DIFF
--- a/.github/workflows/project-hardware.yml
+++ b/.github/workflows/project-hardware.yml
@@ -42,19 +42,35 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Preflight. ProjectsV2 mutations need a PAT with the `project` scope;
-          # the default GITHUB_TOKEN answers "Resource not accessible by
-          # integration". A missing token is a repository-setup gap, not a code
-          # defect, so an `issues` event skips quietly instead of marking every
-          # issue open and close as a failed run. An explicit workflow_dispatch
-          # still fails loudly.
-          if [ "$HAS_PROJECTS_TOKEN" != "true" ]; then
-            echo "::warning title=Project board sync skipped::secrets.PROJECTS_TOKEN is not set; ProjectsV2 needs a PAT with the 'project' scope."
+          # Skip on a setup gap, fail on a real error. An `issues` event fires on
+          # every open and close, so an unusable token must not paint the whole
+          # repository red; an explicit workflow_dispatch must never silently
+          # no-op. Anything past this preflight is a genuine failure.
+          skip_or_fail() {
+            echo "::warning title=Project board sync skipped::$1"
             if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
               echo "workflow_dispatch was explicit - failing instead of skipping." >&2
               exit 1
             fi
             exit 0
+          }
+
+          # 1. Is a token configured at all? Without PROJECTS_TOKEN, GH_TOKEN
+          #    falls back to GITHUB_TOKEN, which cannot touch ProjectsV2 under
+          #    any circumstances.
+          if [ "$HAS_PROJECTS_TOKEN" != "true" ]; then
+            skip_or_fail "secrets.PROJECTS_TOKEN is not set; ProjectsV2 needs a PAT with the 'project' scope."
+          fi
+
+          # 2. Can that token actually reach this project? Presence is not
+          #    access: a PAT can be expired, mis-scoped, or simply belong to an
+          #    account without rights to PROJECT_ID, and each of those failed
+          #    the same way the missing-token case used to. One cheap read
+          #    settles it before any mutation is attempted.
+          if ! gh api graphql -f query='
+            query($id:ID!){ node(id:$id){ ... on ProjectV2 { id } } }
+          ' -f id="$PROJECT_ID" --jq '.data.node.id' >/dev/null 2>&1; then
+            skip_or_fail "secrets.PROJECTS_TOKEN cannot read project $PROJECT_ID - expired, missing the 'project' scope, or not authorized for this owner."
           fi
 
           sync_one() {

--- a/.github/workflows/project-hardware.yml
+++ b/.github/workflows/project-hardware.yml
@@ -67,10 +67,47 @@ jobs:
           #    account without rights to PROJECT_ID, and each of those failed
           #    the same way the missing-token case used to. One cheap read
           #    settles it before any mutation is attempted.
-          if ! gh api graphql -f query='
+          #
+          #    The query itself is captured (not just its exit code) for two
+          #    reasons: `node(id:)` returns a *null* node rather than a GraphQL
+          #    error for an inaccessible/nonexistent id, so a null result must
+          #    be treated the same as a failed call; and a nonzero exit needs
+          #    its error text inspected so a transient outage (5xx, DNS,
+          #    timeout) fails the run instead of being folded into the same
+          #    "no access" skip as an actual 401/403.
+          set +e
+          PREFLIGHT_OUTPUT=$(gh api graphql -f query='
             query($id:ID!){ node(id:$id){ ... on ProjectV2 { id } } }
-          ' -f id="$PROJECT_ID" --jq '.data.node.id' >/dev/null 2>&1; then
+          ' -f id="$PROJECT_ID" 2>&1)
+          PREFLIGHT_STATUS=$?
+          set -e
+
+          auth_denied=0
+          if [ "$PREFLIGHT_STATUS" -ne 0 ]; then
+            if echo "$PREFLIGHT_OUTPUT" | grep -qE 'HTTP (401|403)'; then
+              auth_denied=1
+            else
+              echo "::error title=Project board sync failed::Preflight query errored, not an auth problem - failing rather than masking it as a skip: $PREFLIGHT_OUTPUT" >&2
+              exit 1
+            fi
+          elif [ -z "$(echo "$PREFLIGHT_OUTPUT" | jq -r '.data.node.id // empty')" ]; then
+            auth_denied=1
+          fi
+
+          if [ "$auth_denied" -eq 1 ]; then
             skip_or_fail "secrets.PROJECTS_TOKEN cannot read project $PROJECT_ID - expired, missing the 'project' scope, or not authorized for this owner."
+          fi
+
+          # 3. Read access to the project node is not write access: a
+          #    read-only or mis-scoped-for-mutation token can pass the check
+          #    above and still fail every addProjectV2ItemById /
+          #    updateProjectV2ItemFieldValue call below. Classic PATs (which
+          #    is what PROJECTS_TOKEN is documented to be, above) report their
+          #    grants in the X-OAuth-Scopes response header; confirm 'project'
+          #    is actually one of them before attempting any mutation.
+          TOKEN_SCOPES=$(gh api -i /rate_limit 2>/dev/null | grep -i '^x-oauth-scopes:' | tr -d '\r')
+          if ! echo "$TOKEN_SCOPES" | grep -qw 'project'; then
+            skip_or_fail "secrets.PROJECTS_TOKEN does not carry the 'project' scope (${TOKEN_SCOPES:-no X-OAuth-Scopes header returned}); it can read $PROJECT_ID but item mutations will fail."
           fi
 
           sync_one() {

--- a/.github/workflows/project-hardware.yml
+++ b/.github/workflows/project-hardware.yml
@@ -18,12 +18,20 @@ jobs:
   sync-project:
     runs-on: ubuntu-latest
     steps:
-      - name: Sync issue(s) with org Hardware project
+      - name: Sync issue(s) with the rmems consolidation project
         env:
-          GH_TOKEN: ${{ secrets.PROJECTS_TOKEN || secrets.LIMEN_NEURAL_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          PROJECT_ID: PVT_kwDOEEyGS84BfB8y
-          STATUS_FIELD_ID: PVTSSF_lADOEEyGS84BfB8yzhZX2Lc
-          OPT_READY: "856cdede"
+          # PROJECTS_TOKEN is a classic PAT carrying the `project` scope. The
+          # default GITHUB_TOKEN cannot touch ProjectsV2, so without
+          # PROJECTS_TOKEN this job no-ops (see the preflight below) rather than
+          # failing the run.
+          GH_TOKEN: ${{ secrets.PROJECTS_TOKEN || secrets.GITHUB_TOKEN }}
+          HAS_PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN != '' }}
+          # rmems user project #5 "Limen-Neural Consolidation".
+          # The previous IDs pointed at Limen-Neural org project #8 "Hardware",
+          # which this repository left during the org transfer (#27).
+          PROJECT_ID: PVT_kwHODs2Zb84BfcTG
+          STATUS_FIELD_ID: PVTSSF_lAHODs2Zb84BfcTGzhZvKog
+          OPT_READY: "61e4505c"
           OPT_DONE: "98236657"
           EVENT_NAME: ${{ github.event_name }}
           ISSUE_NUM_EVENT: ${{ github.event.issue.number }}
@@ -33,6 +41,21 @@ jobs:
           REPO: ${{ github.event.repository.name }}
         run: |
           set -euo pipefail
+
+          # Preflight. ProjectsV2 mutations need a PAT with the `project` scope;
+          # the default GITHUB_TOKEN answers "Resource not accessible by
+          # integration". A missing token is a repository-setup gap, not a code
+          # defect, so an `issues` event skips quietly instead of marking every
+          # issue open and close as a failed run. An explicit workflow_dispatch
+          # still fails loudly.
+          if [ "$HAS_PROJECTS_TOKEN" != "true" ]; then
+            echo "::warning title=Project board sync skipped::secrets.PROJECTS_TOKEN is not set; ProjectsV2 needs a PAT with the 'project' scope."
+            if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+              echo "workflow_dispatch was explicit - failing instead of skipping." >&2
+              exit 1
+            fi
+            exit 0
+          fi
 
           sync_one() {
             local NUM="$1"


### PR DESCRIPTION
## **User description**
## What

`Hardware project board` has failed on **every** run since the org transfer — the last four runs all end in `gh: Resource not accessible by integration`, so every issue open/close leaves a red X on the repo. Two independent causes, both fixed here.

### 1. The board IDs point at the old org's project

| Env var | Before | Belongs to | After |
|---|---|---|---|
| `PROJECT_ID` | `PVT_kwDOEEyGS84BfB8y` | **Limen-Neural** org project #8 "Hardware" | `PVT_kwHODs2Zb84BfcTG` — **rmems** user project #5 "Limen-Neural Consolidation" |
| `STATUS_FIELD_ID` | `PVTSSF_lADOEEyGS84BfB8yzhZX2Lc` | old board's Status field | `PVTSSF_lAHODs2Zb84BfcTGzhZvKog` |
| `OPT_READY` | `856cdede` | old board's `Ready` | `61e4505c` |
| `OPT_DONE` | `98236657` | — | `98236657` (unchanged; the two boards happen to share this id) |

The repo left `Limen-Neural` during the transfer; #27 names user project #5 as its board. Every ID was resolved live against the GraphQL API, not guessed.

### 2. No project-scoped token, so the run failed instead of skipping

`GH_TOKEN` fell through to `GITHUB_TOKEN`, which cannot mutate ProjectsV2 under any circumstances. That is a repository-**setup** gap, not a code defect, so a preflight now:

- skips with a `::warning` annotation on `issues` events — no more red X per issue open/close;
- still `exit 1`s on `workflow_dispatch`, so a manual sync cannot silently no-op.

`secrets.LIMEN_NEURAL_GITHUB_TOKEN` is dropped from the fallback chain as a stale org secret name (#27). The step name — which said "org Hardware project" — now matches where it actually writes.

Once a `PROJECTS_TOKEN` PAT with the `project` scope is added to repo secrets, the sync starts working against the right board with no further change.

## Validation

| Check | Result |
|---|---|
| `yaml.safe_load` on the workflow | parses; one job, one step |
| `bash -n` on the extracted step script | clean |
| `HAS_PROJECTS_TOKEN=false EVENT_NAME=issues` | prints the warning, **exit 0** |
| `HAS_PROJECTS_TOKEN=false EVENT_NAME=workflow_dispatch` | prints the warning, **exit 1** |

No Rust files touched, so `cargo` behaviour is unchanged.

## Scope

Workflow only — one file. Does not touch `ci.yml` (#31) or any source (#33), so it does not conflict with either open PR.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwCrGmf3QtQWqHczwQLwWs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the project board sync after the org transfer so issue open/close events no longer leave failed runs. The workflow now targets the rmems user project #5 "Limen-Neural Consolidation" (per #27) and skips with a warning when the configured token can't update it.

- Updates `PROJECT_ID`, `STATUS_FIELD_ID`, and `OPT_READY` to the rmems board; the previous IDs belonged to the Limen-Neural org project the repo left.
- Preflight checks the token is set, can read `PROJECT_ID`, and has the `project` scope, comparing scopes as whole entries so `read:project` doesn't count.
- `issues` events skip with a `::warning` and exit 0; `workflow_dispatch` exits 1 so a manual sync can't silently no-op.
- Non-auth preflight failures, including API rate limits and `/rate_limit` errors, fail the run instead of being skipped as "no access".
- Removes `secrets.LIMEN_NEURAL_GITHUB_TOKEN` as a stale org secret name.

<sup>Written for commit 0750bf02aa361b95eb7f12f5981318acec404ab6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/silicon-bridge/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Restore issue syncing with the rmems consolidation project while handling unavailable project credentials without misleading workflow failures

### What Changed
- Issue updates now target the rmems consolidation project and its current status options
- Missing, unauthorized, expired, or incorrectly scoped project credentials produce a warning and skip automatic issue-triggered runs
- Manually requested syncs still fail when credentials are unavailable, so explicit actions cannot silently do nothing
- Genuine GitHub API failures, including rate limits and service errors, remain visible as failed runs

### Impact
`✅ Issue updates reach the correct project board`
`✅ Fewer red CI runs when project credentials are not configured`
`✅ Clearer failures for invalid tokens and GitHub API outages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
