### PR TITLE
chore: stop publishing agent and CI files to crates.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Documented the two coexisting Q8.8 conventions (unsigned `u16` export vs
   signed `i16` UART stimuli) with a side-by-side table in the crate, module, and
   README docs, plus tests covering both clamp boundaries (#23).
+- The published crate is now an `include` allow-list. `AGENTS.md`, `CLAUDE.md`,
+  `REVIEW.md`, `.codacy.yml`, `.gitignore`, and `.github/` are no longer shipped
+  to crates.io; the tarball drops from 19 files / 99.5 KiB to 12 / 81.5 KiB.
+  `docs/` stays unpublished, as it was under the previous `exclude`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,22 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "SNN-to-FPGA deployment pipeline: Q8.8 fixed-point parameter export, .mem file generation, UART spike readback, and Vivado timing report parsing for neuromorphic hardware"
 repository = "https://github.com/rmems/silicon-bridge"
+documentation = "https://docs.rs/silicon-bridge"
+readme = "README.md"
 keywords = ["snn", "fpga", "neuromorphic", "silicon", "q8-8"]
 categories = ["science", "hardware-support", "algorithms"]
-exclude = ["docs/"]
+# Allow-list rather than `exclude = ["docs/"]`: an exclude list silently ships
+# anything added later, which is how AGENTS.md, CLAUDE.md, REVIEW.md, .codacy.yml
+# and .github/ ended up in the published tarball. docs/ stays out — logo.png
+# alone is 2.4 MB, and crates.io resolves the README's relative links against
+# `repository`.
+include = [
+    "src/**/*.rs",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE-MIT",
+    "LICENSE-APACHE",
+]
 
 [lib]
 name = "silicon_bridge"


### PR DESCRIPTION
## **User description**
> **Updated after review.** The MSRV declaration this PR originally carried moved to #47 — Codex (P1) pointed out the two changes are independently revertible, so AGENTS.md's one-issue-per-PR convention applies. This is packaging only now.

## What

`exclude = ["docs/"]` is a **deny-list**, so anything added to the repo afterwards shipped by default. `cargo package --list` on `main` today:

```
.codacy.yml   .github/workflows/ci.yml   .github/workflows/project-hardware.yml
.gitignore    AGENTS.md   CHANGELOG.md   CLAUDE.md   Cargo.lock   Cargo.toml
LICENSE-APACHE   LICENSE-MIT   README.md   REVIEW.md   src/*.rs
```

`AGENTS.md`, `CLAUDE.md`, and `REVIEW.md` are instructions for coding agents; `.codacy.yml`, `.gitignore` and `.github/` are repo plumbing. None of it means anything to someone who runs `cargo add silicon-bridge`, and a deny-list guarantees the next file added ships too.

Swapped for an `include` allow-list — `src/**/*.rs`, `README.md`, `CHANGELOG.md`, both licences:

| | Before | After |
|---|---|---|
| Files | 19 | 12 |
| Size | 99.5 KiB | 81.5 KiB |
| Compressed | 31.1 KiB | 24.6 KiB |

`docs/` stays unpublished, exactly as under the old `exclude`: `logo.png` alone is 2.4 MB, and crates.io resolves the README's relative links against `repository`, so nothing breaks by leaving it out.

Also fills in `readme` and `documentation`, which were simply absent. Both describe how the package presents on crates.io and docs.rs, so they belong with this change rather than with the MSRV split.

## Validation

| Command | Result |
|---|---|
| `cargo package --list` | the 12 files above |
| `cargo publish --dry-run` | packages and verifies |
| `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo test` | clean |

## Scope

`Cargo.toml` plus one `CHANGELOG.md` entry appended to the end of `### Changed`. No source, workflow, or README changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwCrGmf3QtQWqHczwQLwWs


___

## **CodeAnt-AI Description**
Limit crate packages to consumer-facing files and add package links

### What Changed
- Published crates now contain only Rust source, the README, changelog, and license files; agent instructions, CI configuration, repository settings, and `docs/` are excluded
- Future repository files are not included in crates.io packages unless explicitly selected
- crates.io now links to the README and docs.rs documentation
- The package drops from 19 files / 99.5 KiB to 12 files / 81.5 KiB

### Impact
`✅ Smaller crates.io downloads`
`✅ Cleaner published package contents`
`✅ Direct README and docs.rs links for users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
