### PR TITLE
fix(fpga-export): reject ragged weight rows instead of writing a bad .mem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `FpgaParameterExporter::validate` and `ParameterShapeError` — reject a weight
+  matrix whose rows disagree in length. `MemFileWriter::write_mem_files` now
+  validates before touching the filesystem, so a ragged matrix returns an error
+  instead of writing `.mem` files that load misaligned into `WeightRam`.
+  `ParameterExport::export` stays infallible and still flattens; its rustdoc
+  points at `validate`.
 - `encode_q88_unsigned` — free-function unsigned Q8.8 encoder shared by
   `FixedPointEncode::encode_q88`, `.mem` export, and `format_q88_hex` (#23).
 - `encode_q88_signed`, `q88_signed_to_f32`, `STIMULUS_Q88_MIN`, and

--- a/src/fpga_export.rs
+++ b/src/fpga_export.rs
@@ -64,12 +64,19 @@ pub trait FixedPointEncode {
 /// (`WeightRam`, `NeuronParamRam`).
 pub trait ParameterExport {
     /// Build the full Q8.8 parameter set and metadata.
+    ///
+    /// Weight rows are flattened row-major, and the width is reported as
+    /// `FpgaMetadata::num_channels` from the first row alone. This method is
+    /// infallible, so a ragged matrix still flattens — check the shape with
+    /// [`FpgaParameterExporter::validate`] first, or write through
+    /// [`MemFileWriter::write_mem_files`], which validates for you.
     fn export(&self) -> FpgaParameters;
 }
 
 /// Write Q8.8 parameter vectors as Vivado `$readmemh` `.mem` files.
 pub trait MemFileWriter {
-    /// Error type for filesystem / I/O failures.
+    /// Error type for filesystem / I/O failures, and for a parameter shape
+    /// that cannot be represented as a flat `.mem` file.
     type Error;
 
     /// Write `parameters.mem`, `parameters_weights.mem`, `parameters_decay.mem`,
@@ -86,6 +93,39 @@ pub struct FpgaParameterExporter {
     weights: Vec<Vec<f32>>,
     decay_rates: Vec<f32>,
 }
+
+/// A parameter set whose shape cannot be laid out in FPGA memory.
+///
+/// Returned by [`FpgaParameterExporter::validate`] and, through
+/// `Box<dyn Error>`, by [`MemFileWriter::write_mem_files`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ParameterShapeError {
+    /// The weight rows disagree in length, so the flattened buffer and
+    /// `FpgaMetadata::num_channels` describe different matrices.
+    RaggedWeights {
+        /// Width taken from the first row, and reported as `num_channels`.
+        expected: usize,
+        /// Index of the first row that does not have that width.
+        row: usize,
+        /// Length of that row.
+        len: usize,
+    },
+}
+
+impl std::fmt::Display for ParameterShapeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RaggedWeights { expected, row, len } => write!(
+                f,
+                "weight matrix is not rectangular: row 0 has {expected} channels \
+                 but row {row} has {len}; a flattened .mem file cannot describe it"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ParameterShapeError {}
 
 /// FPGA-compatible parameter format
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -170,6 +210,61 @@ impl FpgaParameterExporter {
             weights,
             decay_rates,
         }
+    }
+
+    /// Check that the weight matrix is rectangular.
+    ///
+    /// [`ParameterExport::export`] flattens the weight rows row-major into a
+    /// single `Vec<u16>` and reports the width as `FpgaMetadata::num_channels`,
+    /// taken from the *first* row. If the rows disagree in length, that pair no
+    /// longer describes the buffer: `WeightRam` addressed as
+    /// `row * num_channels + channel` reads the wrong words from the second row
+    /// onward, and nothing in the `.mem` file reveals it.
+    ///
+    /// An exporter with no weights is rectangular by definition.
+    ///
+    /// ```rust
+    /// use silicon_bridge::{FpgaParameterExporter, ParameterShapeError};
+    ///
+    /// let square = FpgaParameterExporter::from_params(
+    ///     vec![1.0, 1.0],
+    ///     vec![vec![0.5, 0.5], vec![0.5, 0.5]],
+    ///     vec![0.9, 0.9],
+    /// );
+    /// assert!(square.validate().is_ok());
+    ///
+    /// let ragged = FpgaParameterExporter::from_params(
+    ///     vec![1.0, 1.0],
+    ///     vec![vec![0.5, 0.5], vec![0.5]],
+    ///     vec![0.9, 0.9],
+    /// );
+    /// assert_eq!(
+    ///     ragged.validate(),
+    ///     Err(ParameterShapeError::RaggedWeights {
+    ///         expected: 2,
+    ///         row: 1,
+    ///         len: 1,
+    ///     })
+    /// );
+    /// ```
+    pub fn validate(&self) -> Result<(), ParameterShapeError> {
+        let mut rows = self.weights.iter().enumerate();
+        let Some((_, first_row)) = rows.next() else {
+            return Ok(());
+        };
+        let expected = first_row.len();
+
+        for (row, values) in rows {
+            if values.len() != expected {
+                return Err(ParameterShapeError::RaggedWeights {
+                    expected,
+                    row,
+                    len: values.len(),
+                });
+            }
+        }
+
+        Ok(())
     }
 
     fn calculate_memory_usage(&self) -> f32 {
@@ -277,6 +372,11 @@ impl MemFileWriter for FpgaParameterExporter {
     type Error = Box<dyn std::error::Error>;
 
     fn write_mem_files(&self, output_dir: impl AsRef<Path>) -> Result<(), Self::Error> {
+        // Refuse a shape that cannot round-trip through a flat `.mem` file,
+        // before creating anything on disk. A ragged matrix would otherwise
+        // produce files that look valid and load misaligned into `WeightRam`.
+        self.validate()?;
+
         fs::create_dir_all(&output_dir)?;
 
         let params = ParameterExport::export(self);
@@ -603,6 +703,120 @@ mod tests {
         assert!((round_tripped.metadata.target_latency_us - 35.0).abs() < 1e-6);
         // (2 thresholds + 4 weights + 2 decay) * 2 bytes = 16 bytes
         assert!((round_tripped.metadata.memory_usage_kb - 16.0 / 1024.0).abs() < 1e-6);
+    }
+}
+
+#[cfg(test)]
+mod weight_shape_tests {
+    use super::*;
+
+    /// Rows of unequal length, the shape that used to flatten silently.
+    fn ragged() -> FpgaParameterExporter {
+        FpgaParameterExporter::from_params(
+            vec![1.0, 1.0, 1.0],
+            vec![vec![0.5, 0.5], vec![0.5], vec![0.5, 0.5]],
+            vec![0.9, 0.9, 0.9],
+        )
+    }
+
+    #[test]
+    fn rectangular_weights_validate() {
+        let exporter = FpgaParameterExporter::from_params(
+            vec![1.0, 1.0],
+            vec![vec![0.5, 0.5, 0.5], vec![0.25, 0.25, 0.25]],
+            vec![0.9, 0.9],
+        );
+        assert_eq!(exporter.validate(), Ok(()));
+    }
+
+    #[test]
+    fn an_exporter_with_no_weights_validates() {
+        assert_eq!(FpgaParameterExporter::new().validate(), Ok(()));
+    }
+
+    #[test]
+    fn a_single_weight_row_validates() {
+        let exporter =
+            FpgaParameterExporter::from_params(vec![1.0], vec![vec![0.5, 0.5, 0.5]], vec![0.9]);
+        assert_eq!(exporter.validate(), Ok(()));
+    }
+
+    #[test]
+    fn validate_reports_the_first_ragged_row() {
+        assert_eq!(
+            ragged().validate(),
+            Err(ParameterShapeError::RaggedWeights {
+                expected: 2,
+                row: 1,
+                len: 1,
+            })
+        );
+    }
+
+    /// A short row shifts every later weight one slot toward the front, so
+    /// `WeightRam` addressed as `row * num_channels + channel` reads neuron 2's
+    /// first weight where neuron 1's second belongs. The buffer/metadata
+    /// disagreement this asserts is exactly what `validate` now catches.
+    #[test]
+    fn export_flattens_a_ragged_matrix_into_a_buffer_metadata_cannot_describe() {
+        let params = ParameterExport::export(&ragged());
+
+        assert_eq!(params.metadata.num_neurons, 3);
+        assert_eq!(params.metadata.num_channels, 2, "width read from row 0");
+        assert_eq!(params.weights.len(), 5, "2 + 1 + 2 values were flattened");
+        assert_ne!(
+            params.weights.len(),
+            params.metadata.num_neurons * params.metadata.num_channels,
+            "a 3x2 read would run off the end of a 5-word buffer"
+        );
+    }
+
+    #[test]
+    fn write_mem_files_rejects_a_ragged_matrix() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = dir.path().join("export");
+
+        let err = MemFileWriter::write_mem_files(&ragged(), &output)
+            .expect_err("ragged weights should not produce .mem files");
+
+        assert_eq!(
+            err.downcast_ref::<ParameterShapeError>(),
+            Some(&ParameterShapeError::RaggedWeights {
+                expected: 2,
+                row: 1,
+                len: 1,
+            })
+        );
+        assert!(
+            !output.exists(),
+            "the output directory should not be created for an invalid shape"
+        );
+    }
+
+    #[test]
+    fn write_mem_files_still_accepts_a_rectangular_matrix() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let exporter = FpgaParameterExporter::from_params(
+            vec![1.0, 0.75],
+            vec![vec![0.5, 2.0], vec![0.25, 1.5]],
+            vec![0.5, 0.75],
+        );
+
+        MemFileWriter::write_mem_files(&exporter, dir.path()).expect("write_mem_files");
+        assert!(dir.path().join("parameters_weights.mem").exists());
+    }
+
+    #[test]
+    fn the_error_message_names_both_row_widths() {
+        let message = ParameterShapeError::RaggedWeights {
+            expected: 2,
+            row: 1,
+            len: 1,
+        }
+        .to_string();
+
+        assert!(message.contains("row 0 has 2 channels"), "{message}");
+        assert!(message.contains("row 1 has 1"), "{message}");
     }
 }
 

--- a/src/fpga_export.rs
+++ b/src/fpga_export.rs
@@ -223,6 +223,20 @@ impl FpgaParameterExporter {
     ///
     /// An exporter with no weights is rectangular by definition.
     ///
+    /// # What this does not check
+    ///
+    /// Rectangularity only. `thresholds.len()`, `weights.len()` and
+    /// `decay_rates.len()` are **not** required to agree, so sixteen thresholds
+    /// beside four weight rows still validates: it exports `num_neurons: 16`
+    /// with four rows of weights, and `NeuronParamRam` is loaded short.
+    ///
+    /// That is deliberate for now. A partial export — thresholds set, weights
+    /// still to come — is a plausible intermediate state, and turning it into an
+    /// error is a behaviour change that deserves its own decision rather than
+    /// riding along with a corruption fix. [`ParameterShapeError`] is
+    /// `#[non_exhaustive]` so a count-mismatch variant can be added without
+    /// breaking callers.
+    ///
     /// ```rust
     /// use silicon_bridge::{FpgaParameterExporter, ParameterShapeError};
     ///
@@ -717,6 +731,25 @@ mod weight_shape_tests {
             vec![vec![0.5, 0.5], vec![0.5], vec![0.5, 0.5]],
             vec![0.9, 0.9, 0.9],
         )
+    }
+
+    /// `validate` covers rectangularity, not agreement between the three
+    /// vectors. Pinned so the boundary is a decision on record rather than an
+    /// oversight — a count-mismatch variant can be added later without
+    /// breaking callers, since the error enum is `#[non_exhaustive]`.
+    #[test]
+    fn rectangular_rows_validate_even_when_the_vector_lengths_disagree() {
+        let mismatched = FpgaParameterExporter::from_params(
+            vec![1.0; 16],
+            vec![vec![0.5, 0.5]; 4],
+            vec![0.9; 2],
+        );
+
+        assert_eq!(mismatched.validate(), Ok(()));
+
+        let params = ParameterExport::export(&mismatched);
+        assert_eq!(params.metadata.num_neurons, 16, "from the threshold count");
+        assert_eq!(params.weights.len(), 8, "only 4 rows of 2 were supplied");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,8 +75,8 @@ mod fpga_bridge;
 // Re-export public API
 pub use fpga_export::{
     EXPORT_FORMAT_VERSION, FixedPointEncode, FpgaMetadata, FpgaParameterExporter, FpgaParameters,
-    MemFileWriter, ParameterExport, STIMULUS_Q88_MAX, STIMULUS_Q88_MIN, encode_q88_signed,
-    encode_q88_unsigned, format_q88_hex, q88_signed_to_f32, q88_to_f32,
+    MemFileWriter, ParameterExport, ParameterShapeError, STIMULUS_Q88_MAX, STIMULUS_Q88_MIN,
+    encode_q88_signed, encode_q88_unsigned, format_q88_hex, q88_signed_to_f32, q88_to_f32,
 };
 
 pub use fpga_metrics::FpgaMetrics;


### PR DESCRIPTION
## The bug

`ParameterExport::export` flattens the weight matrix row-major into one `Vec<u16>` and reports the width as `FpgaMetadata::num_channels`, read from **row 0 alone** (`src/fpga_export.rs:353-357`). Nothing checks that the rows agree in length.

Give it rows of `[2, 1, 2]`:

| | Value |
|---|---|
| `metadata.num_neurons` | 3 |
| `metadata.num_channels` | 2 — from row 0 |
| `weights.len()` | **5** — `2 + 1 + 2` |
| `num_neurons * num_channels` | **6** |

`WeightRam` addressed as `row * num_channels + channel` then reads neuron 2's first weight where neuron 1's second belongs, and runs off the end of the buffer on the last row. The `.mem` file itself looks perfectly valid — correct `{:04X}` words, right line count, no warning anywhere. The corruption only shows up as wrong spikes on hardware.

## The fix

- **`ParameterShapeError::RaggedWeights { expected, row, len }`** (new, public) — names the width taken from row 0 and the first row that disagrees. `#[non_exhaustive]`, so further shape checks can be added later without a breaking change. Implements `Display` + `Error`.
- **`FpgaParameterExporter::validate()`** (new) — returns it. An exporter with no weights is rectangular by definition.
- **`MemFileWriter::write_mem_files`** validates **before** `create_dir_all`, so an invalid shape leaves nothing on disk rather than a half-written export.
- **`ParameterExport::export`** stays infallible — giving it a `Result` would break the trait, which AGENTS.md calls the stable hardware surface — but its rustdoc now states the hazard and points at `validate`.

Rectangular exports behave exactly as before; every pre-existing test passes untouched.

## Tests

Eight new tests in a `weight_shape_tests` module:

| Test | Covers |
|---|---|
| `rectangular_weights_validate` | the normal path |
| `an_exporter_with_no_weights_validates` | empty is not an error |
| `a_single_weight_row_validates` | one row cannot be ragged |
| `validate_reports_the_first_ragged_row` | exact error payload |
| `export_flattens_a_ragged_matrix_into_a_buffer_metadata_cannot_describe` | **pins the old behaviour** — asserts `weights.len() == 5` while `num_neurons * num_channels == 6`, i.e. the corruption this PR catches |
| `write_mem_files_rejects_a_ragged_matrix` | downcasts the boxed error, and asserts the output directory was **not** created |
| `write_mem_files_still_accepts_a_rectangular_matrix` | no regression on the happy path |
| `the_error_message_names_both_row_widths` | the message is actionable |

Plus a doctest on `validate`.

## Validation

| Command | Result |
|---|---|
| `cargo test` | **45** unit + 4 doctests pass (was 37 + 3) |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo fmt --check` | clean |

## Scope

`src/fpga_export.rs`, one re-export line in `src/lib.rs`, and a `CHANGELOG.md` entry. No `README.md`, no `src/fpga_metrics.rs`, no workflow changes.

One note for whoever merges: the `CHANGELOG.md` entry sits at the top of `### Added`, as does #39's. If both land, expect a one-hunk conflict whose resolution is "keep both bullets".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwCrGmf3QtQWqHczwQLwWs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes FPGA export silently writing corrupted `.mem` files when weight rows are ragged (rows of unequal length). `write_mem_files` now validates the shape before creating any files and returns an error, leaving nothing on disk; `ParameterExport::export` stays infallible but documents the hazard.

**Bug Fixes**
- `FpgaParameterExporter::validate` and `ParameterShapeError::RaggedWeights` are public, reporting the width from row 0 and the first row that disagrees; `validate` deliberately checks only rectangularity, leaving count mismatches across thresholds, weights, and decay rates for a separate decision.
- Rectangular exports behave exactly as before; all existing tests pass unchanged.

<sup>Written for commit 432c7bdee109f78b2aa8bd0d6bd500ce0cbc91ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/silicon-bridge/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

