### PR TITLE
chore(ci): add Dependabot for cargo and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+
+updates:
+  # Cargo.lock is not committed, so a Cargo.toml requirement is the only place a
+  # dependency floor can be raised. Grouped so a quiet week produces one PR, not
+  # five, and capped so a stale queue cannot bury the hand-written PRs.
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      # Conventional Commits, per AGENTS.md.
+      prefix: chore
+      include: scope
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # CI pins `dtolnay/rust-toolchain` by SHA, which never updates on its own and
+  # is exactly the kind of pin that silently rots.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        update-types:
+          - major
+          - minor
+          - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,10 @@ updates:
       day: monday
     open-pull-requests-limit: 3
     commit-message:
-      # Conventional Commits, per AGENTS.md.
+      # Conventional Commits, per AGENTS.md. No dependency scope is listed
+      # there, so leave the scope off rather than let Dependabot's
+      # directory-derived "(deps)" violate the allowed-scopes list.
       prefix: chore
-      include: scope
     groups:
       cargo-minor-and-patch:
         update-types:
@@ -29,7 +30,9 @@ updates:
       day: monday
     open-pull-requests-limit: 3
     commit-message:
-      prefix: ci
+      # "ci" is a valid AGENTS.md scope, not a Conventional Commits type, so
+      # use "chore" with "ci" as the scope rather than "ci:" as the type.
+      prefix: "chore(ci)"
     groups:
       actions:
         update-types:


### PR DESCRIPTION
## **User description**
## What

Nothing in the repo watches dependencies. Two concrete gaps:

- **`Cargo.lock` is gitignored**, so the `Cargo.toml` requirement is the *only* place a dependency floor can be raised. Without a bot, `serde = "1.0"`, `chrono = "0.4"`, `serialport = "4.3"` and `tempfile = "3.10"` never move, and nobody finds out when one of them ships a fix.
- **`.github/workflows/ci.yml` pins `dtolnay/rust-toolchain` by commit SHA** (`67ef31d5…`). A SHA pin is the right supply-chain call *and* the pin most likely to rot unnoticed, precisely because nothing ever nudges it.

## Config

| Ecosystem | Schedule | PR limit | Grouping | Commit prefix |
|---|---|---|---|---|
| `cargo` | weekly, Monday | 3 | minor + patch in one PR | `chore` (with scope) |
| `github-actions` | weekly, Monday | 3 | all update types in one PR | `ci` |

Grouping and the limit are deliberate: a quiet week should produce one PR, not five, and a stale bot queue must not bury the hand-written PRs. Major cargo bumps stay ungrouped so a breaking change arrives on its own and gets read properly.

Commit prefixes use the Conventional Commits types AGENTS.md lists.

## Validation

Parses under `yaml.safe_load` as `version: 2` with both ecosystems resolving as expected. Config-only — no Rust files touched, so `cargo` behaviour is unchanged.

## Scope

One new file, `.github/dependabot.yml`. Touches nothing any other open PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwCrGmf3QtQWqHczwQLwWs


___

## **CodeAnt-AI Description**
Automate weekly Rust dependency and CI action update proposals

### What Changed
- Dependabot checks Rust dependencies every Monday and groups minor and patch updates into one pull request
- Dependabot checks GitHub Actions every Monday, including pinned action updates, and groups all update types into one pull request
- Each ecosystem is limited to three open update pull requests to keep maintenance work manageable
- Generated pull requests use the repository’s accepted commit naming conventions

### Impact
`✅ Weekly dependency update coverage`
`✅ Fewer separate maintenance pull requests`
`✅ Reduced risk of stale CI action pins`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
