### PR TITLE
ci: gate rustdoc warnings so docs.rs breakage fails the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,12 @@ jobs:
 
       - name: Test (uart feature)
         run: cargo test --features uart
+
+      # AGENTS.md bans relative links to licence files in doc comments because
+      # they break on docs.rs — a rule that exists precisely because nothing
+      # rendered the docs. This runs on the uart job because libudev is already
+      # installed here, so `--features uart` covers every public item at once.
+      - name: Rustdoc (deny warnings)
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --no-deps --features uart


### PR DESCRIPTION
## **User description**
> **Stacked on #31** (base `ci/multi-os-uart`), which is what splits `ci.yml` into `fmt` / `test` / `uart` jobs. GitHub retargets this to `main` automatically once #31 merges.

## What

AGENTS.md carries a mandatory rule:

> Do not use relative links to license files in doc comments (they break on docs.rs)

That rule exists precisely because **nothing renders the docs**. CI has never run `cargo doc`, so a broken intra-doc link, an unescaped bracket, or a malformed doc table ships to docs.rs with no signal anywhere.

This adds one step to the existing `uart` job:

```yaml
- name: Rustdoc (deny warnings)
  env:
    RUSTDOCFLAGS: -D warnings
  run: cargo doc --no-deps --features uart
```

A step rather than a new job, for two reasons: `libudev-dev` is already installed there, and `--features uart` documents every public item in one pass, including the feature-gated bridge. No extra runner minutes beyond the doc build itself.

## Validation

The gate was checked in both directions, not just assumed.

**It bites.** Adding `See [`NoSuchItem`].` to the `FpgaMetrics` doc comment:

```
error: unresolved link to `NoSuchItem`
  --> src/fpga_metrics.rs:11:11
   |
11 | /// See [`NoSuchItem`].
   |           ^^^^^^^^^^ no item named `NoSuchItem` in scope
   |
   = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`

error: could not document `silicon-bridge`
```

exit code **101**.

**It passes clean** on the branch as it stands, with the probe reverted — so this is green on merge, not a new red gate to chase.

One finding worth recording for anyone extending this: a broken link in a **private** module's `//!` docs is *not* reported, because rustdoc never renders private modules. The first probe went into `fpga_metrics`'s module header and passed silently; only moving it onto the public `FpgaMetrics` struct produced the error. The gate covers public items — which is also the only surface docs.rs shows.

## Scope

Nine added lines in `.github/workflows/ci.yml`. No source, no README, no `Cargo.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwCrGmf3QtQWqHczwQLwWs


___

## **CodeAnt-AI Description**
Fail CI when public documentation contains warnings

### What Changed
- CI now builds the UART-enabled documentation and treats rustdoc warnings as errors
- Broken links, malformed documentation, and similar issues now fail the build before reaching docs.rs

### Impact
`✅ Fewer broken docs.rs releases`
`✅ Earlier detection of broken documentation links`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `cargo doc` step with `RUSTDOCFLAGS: -D warnings` to the `uart` CI job so broken doc links and malformed doc comments fail the build instead of silently shipping to docs.rs.

- Runs on the `uart` job because `libudev-dev` is already installed there and `--features uart` covers every public item in one pass.
- Verified the gate catches broken intra-doc links (exit 101) and that the branch passes cleanly.
- Broken links in private module docs are not reported, since rustdoc never renders private modules.

<sup>Written for commit c3406a7392e969469e3b07b919fea94b879def6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/silicon-bridge/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

